### PR TITLE
Fix/type errors

### DIFF
--- a/server/src/controllers/menu.js
+++ b/server/src/controllers/menu.js
@@ -1,0 +1,61 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.uploadMenuItemImage = void 0;
+const client_1 = require("@prisma/client");
+const storage_1 = require("../utils/storage");
+const prisma = new client_1.PrismaClient();
+// ... 他のコード ...
+const uploadMenuItemImage = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    var _a;
+    try {
+        const userId = (_a = req.user) === null || _a === void 0 ? void 0 : _a.uid;
+        if (!userId) {
+            return res.status(401).json({ error: "Unauthorized" });
+        }
+        // 画像ファイルがアップロードされているか確認
+        if (!req.file) {
+            return res.status(400).json({ error: "画像ファイルがアップロードされていません" });
+        }
+        const { menuItemId } = req.params;
+        // メニューアイテムの存在確認と権限チェック
+        const menuItem = yield prisma.menuItem.findFirst({
+            where: {
+                id: Number(menuItemId),
+                store: {
+                    owner: {
+                        publicId: userId
+                    }
+                }
+            }
+        });
+        if (!menuItem) {
+            return res.status(404).json({ error: "Menu item not found or unauthorized" });
+        }
+        // Cloud Storageに画像をアップロード
+        const imageUrl = yield (0, storage_1.uploadImage)(req.file, storage_1.StorageFolders.MENU_IMAGES, `menu_${menuItemId}`);
+        // メニューアイテムの画像URLを更新
+        const updatedMenuItem = yield prisma.menuItem.update({
+            where: {
+                id: Number(menuItemId)
+            },
+            data: {
+                imageUrl
+            }
+        });
+        res.json(updatedMenuItem);
+    }
+    catch (error) {
+        console.error("Error uploading menu item image:", error);
+        res.status(500).json({ error: "Internal server error" });
+    }
+});
+exports.uploadMenuItemImage = uploadMenuItemImage;

--- a/server/src/controllers/menu.ts
+++ b/server/src/controllers/menu.ts
@@ -24,12 +24,10 @@ export const uploadMenuItemImage = async (req: AuthRequest, res: Response) => {
     // メニューアイテムの存在確認と権限チェック
     const menuItem = await prisma.menuItem.findFirst({
       where: {
-        id: menuItemId,
-        menu: {
-          store: {
-            owner: {
-              publicId: userId
-            }
+        id: Number(menuItemId),
+        store: {
+          owner: {
+            publicId: userId
           }
         }
       }
@@ -49,7 +47,7 @@ export const uploadMenuItemImage = async (req: AuthRequest, res: Response) => {
     // メニューアイテムの画像URLを更新
     const updatedMenuItem = await prisma.menuItem.update({
       where: {
-        id: menuItemId
+        id: Number(menuItemId)
       },
       data: {
         imageUrl

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -1,0 +1,34 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createUser = void 0;
+const prisma_1 = __importDefault(require("../lib/prisma"));
+const createUser = (_req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const email = `test+${Date.now()}@example.com`;
+        const newUser = yield prisma_1.default.user.create({
+            data: {
+                email,
+                displayName: 'テストユーザー',
+                publicId: `test_${Date.now()}`
+            }
+        });
+        res.json(newUser);
+    }
+    catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'ユーザー作成に失敗しました' });
+    }
+});
+exports.createUser = createUser;

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -9,7 +9,8 @@ export const createUser = async (_req: Request, res: Response) => {
     const newUser = await prisma.user.create({
       data: {
         email,
-        name: 'テストユーザー'
+        displayName: 'テストユーザー',
+        publicId: `test_${Date.now()}`
       }
     });
 

--- a/server/src/tests/auth.test.js
+++ b/server/src/tests/auth.test.js
@@ -1,0 +1,96 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const globals_1 = require("@jest/globals");
+const supertest_1 = __importDefault(require("supertest"));
+const index_1 = require("../index");
+const client_1 = require("@prisma/client");
+const firebase_admin_1 = __importDefault(require("firebase-admin"));
+const prisma = new client_1.PrismaClient();
+const adminAuth = firebase_admin_1.default.auth();
+(0, globals_1.describe)("認証APIのテスト", () => {
+    let testUserToken;
+    let testUserId;
+    (0, globals_1.beforeAll)(() => __awaiter(void 0, void 0, void 0, function* () {
+        // テスト用のユーザーを作成
+        const testUser = yield adminAuth.createUser({
+            email: "test@example.com",
+            password: "password123",
+            displayName: "Test User",
+        });
+        testUserId = testUser.uid;
+        // テスト用のカスタムトークンを作成
+        testUserToken = yield adminAuth.createCustomToken(testUserId);
+    }));
+    (0, globals_1.afterAll)(() => __awaiter(void 0, void 0, void 0, function* () {
+        // テスト用のユーザーを削除
+        yield adminAuth.deleteUser(testUserId);
+        yield prisma.$disconnect();
+    }));
+    (0, globals_1.describe)("GET /api/auth/me", () => {
+        (0, globals_1.it)("認証済みユーザーが自分の情報を取得できる", () => __awaiter(void 0, void 0, void 0, function* () {
+            const response = yield (0, supertest_1.default)(index_1.app)
+                .get("/api/auth/me")
+                .set("Authorization", `Bearer ${testUserToken}`);
+            (0, globals_1.expect)(response.status).toBe(200);
+            (0, globals_1.expect)(response.body).toHaveProperty("publicId", testUserId);
+            (0, globals_1.expect)(response.body).toHaveProperty("email", "test@example.com");
+            (0, globals_1.expect)(response.body).toHaveProperty("displayName", "Test User");
+        }));
+        (0, globals_1.it)("トークンがない場合は401エラーを返す", () => __awaiter(void 0, void 0, void 0, function* () {
+            const response = yield (0, supertest_1.default)(index_1.app).get("/api/auth/me");
+            (0, globals_1.expect)(response.status).toBe(401);
+            (0, globals_1.expect)(response.body).toHaveProperty("error", "No token provided");
+        }));
+        (0, globals_1.it)("無効なトークンの場合は401エラーを返す", () => __awaiter(void 0, void 0, void 0, function* () {
+            const response = yield (0, supertest_1.default)(index_1.app)
+                .get("/api/auth/me")
+                .set("Authorization", "Bearer invalid-token");
+            (0, globals_1.expect)(response.status).toBe(401);
+        }));
+    });
+    (0, globals_1.describe)("PUT /api/auth/me", () => {
+        (0, globals_1.it)("認証済みユーザーが表示名を更新できる", () => __awaiter(void 0, void 0, void 0, function* () {
+            const newDisplayName = "Updated Test User";
+            const response = yield (0, supertest_1.default)(index_1.app)
+                .put("/api/auth/me")
+                .set("Authorization", `Bearer ${testUserToken}`)
+                .send({ displayName: newDisplayName });
+            (0, globals_1.expect)(response.status).toBe(200);
+            (0, globals_1.expect)(response.body).toHaveProperty("displayName", newDisplayName);
+        }));
+        (0, globals_1.it)("トークンがない場合は401エラーを返す", () => __awaiter(void 0, void 0, void 0, function* () {
+            const response = yield (0, supertest_1.default)(index_1.app)
+                .put("/api/auth/me")
+                .send({ displayName: "New Name" });
+            (0, globals_1.expect)(response.status).toBe(401);
+            (0, globals_1.expect)(response.body).toHaveProperty("error", "No token provided");
+        }));
+        (0, globals_1.it)("無効なトークンの場合は401エラーを返す", () => __awaiter(void 0, void 0, void 0, function* () {
+            const response = yield (0, supertest_1.default)(index_1.app)
+                .put("/api/auth/me")
+                .set("Authorization", "Bearer invalid-token")
+                .send({ displayName: "New Name" });
+            (0, globals_1.expect)(response.status).toBe(401);
+        }));
+        (0, globals_1.it)("表示名が空の場合は400エラーを返す", () => __awaiter(void 0, void 0, void 0, function* () {
+            const response = yield (0, supertest_1.default)(index_1.app)
+                .put("/api/auth/me")
+                .set("Authorization", `Bearer ${testUserToken}`)
+                .send({ displayName: "" });
+            (0, globals_1.expect)(response.status).toBe(400);
+            (0, globals_1.expect)(response.body).toHaveProperty("error", "Display name cannot be empty");
+        }));
+    });
+});

--- a/server/src/tests/auth.test.ts
+++ b/server/src/tests/auth.test.ts
@@ -2,21 +2,10 @@ import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
 import request from "supertest";
 import { app } from "../index";
 import { PrismaClient } from "@prisma/client";
-import { adminAuth } from "../config/firebase";
-import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
-import { initializeApp } from "firebase/app";
+import admin from "firebase-admin";
 
 const prisma = new PrismaClient();
-
-// Firebaseクライアントの初期化
-const firebaseConfig = {
-  apiKey: process.env.VITE_FIREBASE_API_KEY,
-  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.VITE_FIREBASE_PROJECT_ID,
-};
-
-const firebaseApp = initializeApp(firebaseConfig);
-const auth = getAuth(firebaseApp);
+const adminAuth = admin.auth();
 
 describe("認証APIのテスト", () => {
   let testUserToken: string;
@@ -32,9 +21,8 @@ describe("認証APIのテスト", () => {
 
     testUserId = testUser.uid;
 
-    // テスト用のユーザーでログインしてIDトークンを取得
-    const userCredential = await signInWithEmailAndPassword(auth, "test@example.com", "password123");
-    testUserToken = await userCredential.user.getIdToken();
+    // テスト用のカスタムトークンを作成
+    testUserToken = await adminAuth.createCustomToken(testUserId);
   });
 
   afterAll(async () => {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -59,7 +59,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
@@ -109,5 +109,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
# TypeScriptの型エラー修正

## 変更内容
1. `menu.ts`の修正
   - `menuItemId`を`Number()`で数値に変換
   - Prismaの`id`フィールドの型（`number`）に合わせる

2. `userController.ts`の修正
   - `name`フィールドを`displayName`に変更
   - PrismaのUserモデルの定義に合わせる

3. `auth.test.ts`の修正
   - クライアントSDK（`firebase/auth`、`firebase/app`）の削除
   - `firebase-admin`の直接使用に変更
   - テスト用のトークン生成方法を`createCustomToken`に変更

## 修正の背景
TypeScriptのビルド時に以下のエラーが発生していました：
- `menuItemId`の型が`string`で、`number`が必要
- Userモデルの`name`フィールドが存在しない
- サーバー側でクライアントSDKを使用している

## 期待される効果
- TypeScriptのビルドが正常に完了する
- 型の整合性が保たれる
- サーバー側のコードが適切なライブラリを使用する

## テスト方法
1. `npm run build`を実行して型エラーが解消されていることを確認
2. テストを実行して機能が正常に動作することを確認