### PR TITLE
feat(server): add Vercel domain to CORS whitelist

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -31,7 +31,13 @@ const port = Number(process.env.PORT) || 3000;
 
 // CORSの設定
 app.use(cors({
-  origin: ['http://localhost:5173', 'http://192.168.1.50:5173', 'http://192.168.1.59:5173', 'http://192.168.1.70:5173'],
+  origin: [
+    'https://q-menu-iota.vercel.app',
+    'http://localhost:5173',
+    'http://192.168.1.50:5173',
+    'http://192.168.1.59:5173',
+    'http://192.168.1.70:5173'
+  ],
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization']


### PR DESCRIPTION
Vercel 本番 URL からのリクエストを許可するため