### PR TITLE
fix(store): 営業時間未設定時にも編集アイコンを表示し初期データを生成

### DIFF
--- a/client/src/components/store/StoreForm.tsx
+++ b/client/src/components/store/StoreForm.tsx
@@ -740,7 +740,26 @@ export const StoreForm = () => {
                   })}
                 </ul>
               ) : (
-                <Typography sx={{ color: 'text.secondary' }}>未設定</Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <Typography sx={{ color: 'text.secondary' }}>未設定</Typography>
+                  <EditIconButton
+                    onClick={() => handleEditButton(() => {
+                      // デフォルトの営業時間データを生成（月曜営業、他休業）
+                      const defaultHours: BusinessHours[] = [
+                        { dayOfWeek: 'monday', periods: [{ isOpen: true, openTime: '09:00', closeTime: '17:00' }] },
+                        { dayOfWeek: 'tuesday', periods: [{ isOpen: false, openTime: '09:00', closeTime: '17:00' }] },
+                        { dayOfWeek: 'wednesday', periods: [{ isOpen: false, openTime: '09:00', closeTime: '17:00' }] },
+                        { dayOfWeek: 'thursday', periods: [{ isOpen: false, openTime: '09:00', closeTime: '17:00' }] },
+                        { dayOfWeek: 'friday', periods: [{ isOpen: false, openTime: '09:00', closeTime: '17:00' }] },
+                        { dayOfWeek: 'saturday', periods: [{ isOpen: false, openTime: '09:00', closeTime: '17:00' }] },
+                        { dayOfWeek: 'sunday', periods: [{ isOpen: false, openTime: '09:00', closeTime: '17:00' }] },
+                      ];
+                      setBusinessHours(defaultHours);
+                      setEditDayOfWeek('monday');
+                      setTempDayBusinessHours([...defaultHours[0].periods]);
+                    })}
+                  />
+                </Box>
               )}
             </Box>
           </Box>


### PR DESCRIPTION
目的
店舗情報画面で businessHours が空の場合、
「営業時間」ブロックにペン（編集）アイコンが表示されず
初回入力に進めない問題を修正しました。
変更点
client/src/components/store/StoreForm.tsx
営業時間リストが空 (businessHours.length === 0) の場合でも
「未設定」の右側に EditIconButton を表示。
クリック時に 7 曜日分のデフォルトデータを生成し
月曜日：09:00〜17:00（営業）
火〜日：休業
businessHours ステートへセットし、月曜日を編集モードへ遷移。
動作確認
DB で business_hours を空配列にして画面をリロード
「営業時間」行にペンアイコンが表示される
クリックすると月曜の編集 UI が開き、保存可能
既に営業時間が登録済みの場合は従来通りの UI が表示されること
影響範囲
フロントエンドの StoreForm コンポーネントのみ。
既存データ編集フローには影響なし。
補足
・デフォルト営業時間は仮値（09:00〜17:00）です。
　必要に応じて変更してください。