### PR TITLE
chore(vercel): add SPA rewrite to fix preview 404

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "^/(?!api).*", "destination": "/index.html" }
+  ]
+} 


### PR DESCRIPTION
Vercel で静的 SPA をホスティングする際、
API 以外のルートは index.html にリライトする必要があります。
/qr などのプレビュー URL が 404 になる問題を解消するため、
vercel.json を追加して
Apply to .env
}
というリライト設定を追加しました。
1.ルート直下に vercel.json を新規作成
2.既存機能への影響なし（フロント側経路のみ）
マージ後、Vercel の再デプロイが完了すれば
https://q-menu-iota.vercel.app/qr などの URL でプレビュー表示が動作するはずです。