### PR TITLE
chore(client vercel): add SPA rewrite so preview routes resolve to fix preview 404

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "^/(?!api).*", "destination": "/index.html" }
+  ]
+} 


### PR DESCRIPTION
Vercel の Frontend サービスは client/ ディレクトリをビルド対象としているため、
リライト設定も同階層で読み込ませる必要がありました。
client/vercel.json に
Apply to .env
}
を追加し、/qr や /menu/:storeId などの SPA ルートが 404 にならないようにしました。
マージ後のデプロイ完了後に再度 URL を確認いただければ表示されるはずです。