### PR TITLE
fix(vercel): SPA ルーティング用 rewrite をシンプルに統一

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,5 +1,5 @@
 {
   "rewrites": [
-    { "source": "^/(?!api).*", "destination": "/index.html" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 } 


### PR DESCRIPTION
概要
Vercel で動作するクライアント SPA のルーティングを安定させるため、client/vercel.json の rewrites をシンプルな /(.*) → /index.html に置き換えました。これにより /qr や /menu/:id などの動的ルートが 404 になる問題を解消します。
背景
これまでの negative-lookahead 正規表現 (^/(?!api).*) は Vercel のバリデーションで warning が出る場合があり、保守性も低かった。
プロジェクト設定で Vercel の Root Directory を client に固定したため、API との競合は発生しない。そこで全パスを index.html に転送する最小構成に変更する。
変更内容
client/vercel.json
source を "^/(?!api).*" → "/(.*)" に変更。
動作確認手順
この PR をマージして Vercel の Preview デプロイを確認。
/, /qr, /menu/1 など、任意のクライアントルートへ直接アクセスしてアプリが正しく表示されることを確認。
ローカルでも npm run build && npx serve -s dist で同様の動きをテスト可能。
影響範囲
クライアント側 SPA ルーティングのみ。
サーバー/API 側の挙動およびデータベースには影響なし。
補足
ルート直下の vercel.json はビルド対象外（Root Directory が client のため）ですが、不要であれば別途削除してください。