### PR TITLE
fix(phase3): CORS を動的判定に変更し *.vercel.app Preview を許可

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,14 +32,26 @@ const app = express();
 const port = Number(process.env.PORT) || 3000;
 
 // CORSの設定
+const staticOrigins = [
+  'http://localhost:5173',
+  'http://192.168.1.50:5173',
+  'http://192.168.1.59:5173',
+  'http://192.168.1.70:5173',
+  'https://q-menu-iota.vercel.app'
+];
+
 app.use(cors({
-  origin: [
-    'https://q-menu-iota.vercel.app',
-    'http://localhost:5173',
-    'http://192.168.1.50:5173',
-    'http://192.168.1.59:5173',
-    'http://192.168.1.70:5173'
-  ],
+  origin: (origin, callback) => {
+    if (!origin) return callback(null, true); // mobile app / curl
+
+    // allow static list
+    if (staticOrigins.includes(origin)) return callback(null, true);
+
+    // allow all *.vercel.app previews
+    if (/\.vercel\.app$/.test(origin)) return callback(null, true);
+
+    return callback(new Error('Not allowed by CORS'));
+  },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization']


### PR DESCRIPTION
## 背景
Vercel Preview 環境（branch URL など）から API へアクセスした際に
Access-Control-Allow-Origin header is missing
となり `/api/stores/owner` が CORS でブロック → 画面がローディングのまま停止していた。

## 変更点
server/src/index.ts
- 既存の `cors({ origin: [...] })` 配列を削除
- `origin` をコールバック関数に変更し動的に判定
  - 固定許可リスト:  
    `http://localhost:5173`, `http://192.168.x.x:5173`, `https://q-menu-iota.vercel.app`
  - 正規表現: `*.vercel.app` の Preview ドメインをすべて許可
- 他の設定（credentials, methods, headers）は従来どおり

## 動作確認
1. Vercel Preview URL（例: https://qr-menu-git-<branch>.vercel.app）を開き
   - `/api/stores/owner` が 200（または 404）で返り、ローディングが解除される
2. 本番 URL・ローカル環境でも API が正常に通ること
3. Sentry に CORS 関連の新規エラーが上がらないこと

## 影響範囲
バックエンドの CORS レイヤーのみ。  
フロントエンド／DB には影響なし。

## 備考
- 今後ドメインを追加する場合は `staticOrigins` に追記 or 正規表現を調整してください。