### PR TITLE
fix(qr): APP_URL / VITE_APP_URL を環境変数化し localhost 固定を解消

### DIFF
--- a/client/src/components/QRCodeGenerator.tsx
+++ b/client/src/components/QRCodeGenerator.tsx
@@ -3,7 +3,8 @@ import { generateQRCode } from '../api/qr';
 import { getStoreInfo } from '../api/store';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-const APP_URL = import.meta.env.VITE_APP_URL || 'http://localhost:5173';
+// フロントエンド公開 URL（QR プレビュー用）
+const APP_URL = import.meta.env.VITE_APP_URL || window.location.origin;
 
 const QRCodeGenerator: React.FC = () => {
   const [storeId, setStoreId] = useState<string | null>(null);

--- a/env.example
+++ b/env.example
@@ -1,0 +1,12 @@
+# Environment Variables Example
+
+# フロントエンドの公開 URL (例: https://app.qrmenu.jp)
+APP_URL=http://localhost:5173
+
+# クライアント側で参照する公開 URL (Vite 用)
+VITE_APP_URL=http://localhost:5173
+
+# 開発時にスマホで確認する場合は PC の LAN IP を指定する
+# 例)
+# APP_URL=http://192.168.0.12:5173
+# VITE_APP_URL=http://192.168.0.12:5173 

--- a/server/src/controllers/qr.ts
+++ b/server/src/controllers/qr.ts
@@ -17,7 +17,13 @@ export const generateQRCode = async (req: Request, res: Response) => {
       return res.status(400).json({ error: "storeId is required" });
     }
 
-    const APP_URL = process.env.APP_URL || 'http://localhost:5173';
+    // QR に埋め込むフロントエンド URL
+    const APP_URL = process.env.APP_URL;
+    if (!APP_URL) {
+      console.error('[QR] APP_URL is not defined in environment variables');
+      return res.status(500).json({ error: 'Server configuration error: APP_URL is not set' });
+    }
+
     const qrUrl = `${APP_URL}/menu/${storeId}`;
     const fileName = `store_${storeId}_${Date.now()}.png`;
     const filePath = path.join(qrDir, fileName);


### PR DESCRIPTION
目的
QR コードに埋め込む URL が http://localhost:5173 に固定されていたため、
スマホ実機や本番環境で QR を読み込むと接続できない問題を解消する。
変更点
1.server/src/controllers/qr.ts
APP_URL を必須環境変数化
未設定時は 500 を返してログにエラーを出力
2.client/src/components/QRCodeGenerator.tsx
import.meta.env.VITE_APP_URL を参照
未設定時は window.location.origin をフォールバック
3.env.example 追加
APP_URL / VITE_APP_URL サンプル値と LAN IP 用の説明を記載


環境変数（Render / Vercel で追加が必要）
Key--VITE_APP_URL
Value (例)--https://app.qrmenu.jp
使用箇所 -------
frontend (プレビュー/ボタン) ### 動作確認手順 
1. .env.development.local に LAN IP を設定し npm run dev で起動 
2. QR を生成 → スマホ実機でスキャンしプレビューが開くことを確認  
3. 本番環境に環境変数を追加後、再デプロイ → 同手順で確認 ### 関連タスク * docs/sub/progress/task_progress.md : fix/phase3/qr-app-url ### レビュー観点 * APP_URL 未設定時のハンドリングに問題がないか * 既存機能（QR 生成、ダウンロード）に影響しないか

