### PR TITLE
fix(ui): メニューカードの幅・高さを統一し詳細モーダルに価格を追加

### DIFF
--- a/client/src/components/DescriptionModal.tsx
+++ b/client/src/components/DescriptionModal.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import './DescriptionModal.css';
 
 interface DescriptionModalProps {
-  description: string;
+  description?: string;
   title: string;
+  price: number;
   onClose: () => void;
 }
 
-const DescriptionModal: React.FC<DescriptionModalProps> = ({ description, title, onClose }) => {
+const DescriptionModal: React.FC<DescriptionModalProps> = ({ description, title, price, onClose }) => {
   return (
     <div className="description-modal-overlay" onClick={onClose}>
       <div className="description-modal-content" onClick={e => e.stopPropagation()}>
@@ -18,7 +19,8 @@ const DescriptionModal: React.FC<DescriptionModalProps> = ({ description, title,
           </button>
         </div>
         <div className="description-modal-body" style={{ whiteSpace: 'pre-line' }}>
-          {description}
+          <p style={{ fontWeight: 700, marginTop: 0 }}>{price.toLocaleString()}円</p>
+          {description && <p>{description}</p>}
         </div>
       </div>
     </div>

--- a/client/src/pages/MenuDisplay.css
+++ b/client/src/pages/MenuDisplay.css
@@ -94,7 +94,7 @@
 }
 .menu-grid-responsive {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 16px;
   padding: 8px;
 }
@@ -106,9 +106,8 @@
   display: flex;
   flex-direction: column;
   transition: transform 0.2s, box-shadow 0.2s;
-  min-width: 160px;
-  max-width: 200px;
-  margin: 0 auto;
+  width: 180px;
+  margin: 0;
 }
 .menu-item-card:hover {
   transform: translateY(-2px);
@@ -121,7 +120,8 @@
 }
 .menu-item-img {
   width: 100%;
-  height: 120px;
+  aspect-ratio: 4 / 3;
+  height: auto;
   object-fit: cover;
   background: #f5e6d3;
 }
@@ -136,6 +136,9 @@
   font-size: 16px;
   color: #8b4513;
   margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .menu-item-price {
   color: #d35400;

--- a/client/src/pages/MenuDisplay.tsx
+++ b/client/src/pages/MenuDisplay.tsx
@@ -17,7 +17,7 @@ const MenuDisplay: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [selectedImage, setSelectedImage] = useState<{ url: string; alt: string } | null>(null);
-  const [selectedDescription, setSelectedDescription] = useState<{ text: string; title: string } | null>(null);
+  const [selectedItem, setSelectedItem] = useState<MenuItem | null>(null);
   // カテゴリごとのrefを管理
   const categoryRefs = useRef<{ [key: number]: HTMLDivElement | null }>({});
   // 店舗情報セクションのref
@@ -91,11 +91,12 @@ const MenuDisplay: React.FC = () => {
           onClose={() => setSelectedImage(null)}
         />
       )}
-      {selectedDescription && (
+      {selectedItem && (
         <DescriptionModal
-          description={selectedDescription.text}
-          title={selectedDescription.title}
-          onClose={() => setSelectedDescription(null)}
+          title={selectedItem.name}
+          description={selectedItem.description || ''}
+          price={selectedItem.price}
+          onClose={() => setSelectedItem(null)}
         />
       )}
       {/* サイドバー（PC） or タブ（モバイル） */}
@@ -258,23 +259,26 @@ const MenuDisplay: React.FC = () => {
                         )}
                       </div>
                       <div className="menu-item-content">
-                        <div className="menu-item-name">{item.name}</div>
-                        <div className="menu-item-price">{item.price}円</div>
-                        {item.description && (
-                          <div 
-                            className="menu-item-desc"
-                            onClick={() => setSelectedDescription({ text: item.description!, title: item.name })}
-                            role="button"
-                            tabIndex={0}
-                            onKeyPress={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                setSelectedDescription({ text: item.description!, title: item.name });
-                              }
-                            }}
-                          >
-                            {item.description}
-                          </div>
-                        )}
+                        <div 
+                          className="menu-item-content-clickable"
+                          onClick={() => setSelectedItem(item)}
+                          role="button"
+                          tabIndex={0}
+                          onKeyPress={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              setSelectedItem(item);
+                            }
+                          }}
+                          style={{ cursor: 'pointer' }}
+                        >
+                          <div className="menu-item-name">{item.name}</div>
+                          <div className="menu-item-price">{item.price}円</div>
+                          {item.description && (
+                            <div className="menu-item-desc">
+                              {item.description}
+                            </div>
+                          )}
+                        </div>
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
目的
スマホ／PC いずれもカード幅・高さが揃わず段組みが崩れる問題を解消し、
カードタップ時に価格を含む詳細情報を表示できるようにする。
変更点
1. client/src/pages/MenuDisplay.css
.menu-item-card を固定幅 180px に変更、min/max-width を削除
画像を aspect-ratio: 4/3 指定で比率維持
料理名・説明文を 1 行省略 (white-space: nowrap; overflow: hidden; text-overflow: ellipsis)
2. client/src/components/DescriptionModal.tsx
price を props に追加
モーダル本文で「価格 ➜ 説明」の順に表示
3. client/src/pages/MenuDisplay.tsx
selectedItem state を新設し、カード下部クリックでモーダル表示
旧 selectedDescription ロジックを置き換え
画像クリック時の拡大モーダルは現状維持

動作確認手順
1.ローカル／プレビュー URL でメニュー画面を表示
2.幅を変えてもカードが 180px 幅で整列することを確認
3.カード画像以外の白い領域をタップすると
   ・料理名・価格・説明がモーダル表示される
4.画像をタップすると従来どおり拡大モーダルが表示される