### PR TITLE
fix(menu-display): モバイルカード幅160/140pxとモーダル区切り線追加

### DIFF
--- a/client/src/components/DescriptionModal.tsx
+++ b/client/src/components/DescriptionModal.tsx
@@ -19,8 +19,9 @@ const DescriptionModal: React.FC<DescriptionModalProps> = ({ description, title,
           </button>
         </div>
         <div className="description-modal-body" style={{ whiteSpace: 'pre-line' }}>
-          <p style={{ fontWeight: 700, marginTop: 0 }}>{price.toLocaleString()}円</p>
-          {description && <p>{description}</p>}
+          <p style={{ fontWeight: 700, margin: '0 0 6px' }}>{price.toLocaleString()}円</p>
+          <hr style={{ border: 'none', borderTop: '1px solid #333', margin: '4px 0 6px' }} />
+          {description && <p style={{ margin: 0 }}>{description}</p>}
         </div>
       </div>
     </div>

--- a/client/src/pages/MenuDisplay.css
+++ b/client/src/pages/MenuDisplay.css
@@ -216,11 +216,11 @@
     padding: 24px 16px 24px 24px;
   }
   .menu-grid-responsive {
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
     gap: 12px;
   }
   .menu-item-card {
-    min-width: 140px;
+    min-width: 160px;
   }
 }
 
@@ -243,11 +243,11 @@
     padding: 16px 8px 16px 16px;
   }
   .menu-grid-responsive {
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
     gap: 8px;
   }
   .menu-item-card {
-    min-width: 120px;
+    min-width: 140px;
   }
   .menu-item-img {
     height: 100px;

--- a/docs/sub/progress/task_progress.md
+++ b/docs/sub/progress/task_progress.md
@@ -334,3 +334,13 @@
 
 | ✅ | chore/phase3/firebase-storage-prod | 2025-06-19 | Firebase Storage 本番ルール設定 & 鍵の環境変数化 | Sentry 導入 |
 | 🔄 | feature/phase3/observability-setup | 2025-06-19 | Sentry 導入＋DB dump cron | Onboarding 資料ドラフト |
+
+## 2025-06-23: モバイルレイアウト改善＆モーダル調整
+- ステータス: 🔄進行中
+- ブランチ: `fix/phase3/mobile-layout-modal`
+- 開始日: 2025-06-23
+- 作業内容:
+  - モバイル向けメニューカード幅の調整（900px:160px, 600px:140px）
+  - grid minmax値の変更に伴うレイアウト最適化
+  - モーダルに区切り線 `<hr>` を追加し、価格上下の余白を縮小
+- 次のタスクへの引き継ぎ事項: デザイン確認後、追加フィードバックに応じて微調整予定


### PR DESCRIPTION
概要
モバイル表示時にカードが崩れる問題と、詳細モーダルの区切り線追加要望への対応です。

変更点
1.MenuDisplay.css
・画面幅 ≤ 900 px：
　・.menu-item-card 幅を 160 px に固定
　・grid-template-columns を minmax(160px, 1fr) に変更
　・gap を 12 px に調整
・画面幅 ≤ 600 px：
　・カード幅 140 px、minmax(140px, 1fr)、gap 8 px
・デスクトップ（>900 px）は従来の 180 px を維持
2.DescriptionModal.tsx
・価格表示直下に <hr> を挿入し、価格と説明文を視覚的に分離
・価格表示・区切り線・説明文の余白を最適化
3.docs/sub/progress/task_progress.md
・タスク開始（🔄進行中）を追記

動作確認
・Chrome DevTools / iPhone SE・Pixel 6 プレビューで以下を確認
　・グリッド崩れが解消され、カード幅が指定どおり 160 px / 140 px で均一
　・横スクロールバーの発生なし
　・モーダルに区切り線が表示され、価格と説明文が読みやすくなった
・デスクトップ表示（幅 1440 px）では既存レイアウトに影響なし