### PR TITLE
fix(menu-display): モバイル用ブレイクポイント調整（430 / 400 / 360px）

### DIFF
--- a/client/src/pages/MenuDisplay.css
+++ b/client/src/pages/MenuDisplay.css
@@ -268,7 +268,7 @@
   }
 }
 
-/* --- 430px 以下：サイドバーを更に縮小、カード120px --- */
+/* --- 430px 以下：サイドバー縮小のみ --- */
 @media (max-width: 430px) {
   .menu-sidebar-responsive {
     width: 80px;
@@ -286,6 +286,10 @@
   .menu-main-responsive {
     padding: 12px 4px 12px 8px;
   }
+}
+
+/* --- 400px 以下：カード120px --- */
+@media (max-width: 400px) {
   .menu-grid-responsive {
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     gap: 6px;
@@ -311,8 +315,8 @@
   }
 }
 
-/* --- 330px 以下：さらにカードを100px に --- */
-@media (max-width: 330px) {
+/* --- 360px 以下：さらにカードを100px に --- */
+@media (max-width: 360px) {
   .menu-grid-responsive {
     grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
     gap: 4px;


### PR DESCRIPTION
### 概要
モバイル表示で 2 列レイアウトを維持するため、以下 3 つのブレイクポイントを追加・修正しました。

- **430px 以下**
  - サイドバー幅を `80px` に縮小
- **400px 以下**
  - カード幅を `120px` に変更（`minmax(120px, 1fr)`）
- **360px 以下**
  - カード幅を `100px` に変更（`minmax(100px, 1fr)`）

### 変更箇所
- `client/src/pages/MenuDisplay.css`
  - 上記ブレイクポイントの追加・コメント追記のみ

### 動作確認
- 428px：カード 140px ×2 列
- 398px：カード 120px ×2 列
- 360px：カード 100px ×2 列
- 320px：カード 100px ×2 列（横スクロールなし）
- デスクトップ(≥1024px) ではレイアウト変化なし

### 備考
- `fix/phase3/mobile-layout-fine-tune` のフォローアップ PR