### PR TITLE
test(backend): Auth API 統合テストを追加しテストカバレッジ向上

### DIFF
--- a/server/tests/auth.test.ts
+++ b/server/tests/auth.test.ts
@@ -1,0 +1,89 @@
+import { PrismaClient } from '@prisma/client';
+import { app } from '../src/app';
+import request from 'supertest';
+
+const prisma = new PrismaClient();
+
+describe('Auth API Tests', () => {
+  let testUser: any;
+
+  beforeAll(async () => {
+    // Firebase モックの uid と揃える
+    testUser = await prisma.user.upsert({
+      where: { publicId: 'test-user-id' },
+      update: {
+        email: 'auth@test.com',
+        displayName: 'Auth Tester',
+      },
+      create: {
+        email: 'auth@test.com',
+        publicId: 'test-user-id',
+        displayName: 'Auth Tester',
+        role: 'OWNER',
+      }
+    });
+
+    // ユーザーに紐づく店舗が無いとミドルウェアが 404 を返すため、店舗も用意しておく
+    await prisma.store.upsert({
+      where: { ownerId: testUser.id },
+      update: {
+        name: 'Auth Store'
+      },
+      create: {
+        name: 'Auth Store',
+        ownerId: testUser.id
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.store.deleteMany();
+    await prisma.user.deleteMany();
+    await prisma.$disconnect();
+  });
+
+  describe('GET /api/auth/me', () => {
+    it('should return user info for authenticated request', async () => {
+      const res = await request(app)
+        .get('/api/auth/me')
+        .set('Authorization', 'Bearer test-token');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('email', 'auth@test.com');
+    });
+
+    it('should return 401 for unauthenticated request', async () => {
+      const res = await request(app).get('/api/auth/me');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('PUT /api/auth/me', () => {
+    it('should update displayName', async () => {
+      const res = await request(app)
+        .put('/api/auth/me')
+        .set('Authorization', 'Bearer test-token')
+        .send({ displayName: 'Updated Name' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('displayName', 'Updated Name');
+    });
+
+    it('should validate required fields', async () => {
+      const res = await request(app)
+        .put('/api/auth/me')
+        .set('Authorization', 'Bearer test-token')
+        .send({ displayName: '' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 401 for unauthenticated request', async () => {
+      const res = await request(app)
+        .put('/api/auth/me')
+        .send({ displayName: 'Should fail' });
+
+      expect(res.status).toBe(401);
+    });
+  });
+}); 


### PR DESCRIPTION
## ✨ 概要
`/api/auth/me` 取得・更新エンドポイントの統合テスト（Jest + Supertest）を実装し、認証関連の基本動作を自動検証できるようにしました。  
これにより CI 上でも Auth API の回帰が検知できます。

## 🔄 変更点
### テスト
- `server/tests/auth.test.ts` を新規追加  
  - GET `/api/auth/me`  
    - 認証あり: 200 & ユーザー情報
    - 認証なし: 401  
  - PUT `/api/auth/me`  
    - 正常更新: 200 & displayName 更新確認  
    - バリデーション失敗: 400  
    - 認証なし: 401  
  - 事前に `user` + `store` を upsert で用意し、後処理でクリーンアップ

### その他
- 既存コード変更なし（DB スキーマ・アプリ挙動への影響なし）

## 🧪 テスト結果
ローカル実行  
CI でも同様にグリーンを確認済み。

## 📈 影響範囲
- Backend のテストコードのみ。アプリ本体には影響なし。

## 📝 補足
- 今後の予定: QR 生成 API、並び替え API など P0 項目の追加テストを進行予定。
- `docs/sub/progress/task_progress.md` に ✅ 完了 を記録済み。