### PR TITLE
test(backend): メニューカテゴリー並び替え API の統合テストを追加

### DIFF
--- a/server/tests/reorderCategories.test.ts
+++ b/server/tests/reorderCategories.test.ts
@@ -1,0 +1,87 @@
+import { PrismaClient } from '@prisma/client';
+import { app } from '../src/app';
+import request from 'supertest';
+
+const prisma = new PrismaClient();
+
+describe('Menu Category Reorder API Tests', () => {
+  let user: any;
+  let store: any;
+  let categoryA: any;
+  let categoryB: any;
+  let otherStoreCategory: any;
+
+  beforeAll(async () => {
+    user = await prisma.user.upsert({
+      where: { publicId: 'test-user-id' },
+      update: {},
+      create: {
+        publicId: 'test-user-id',
+        email: 'catreorder@test.com',
+        role: 'OWNER'
+      }
+    });
+
+    store = await prisma.store.upsert({
+      where: { ownerId: user.id },
+      update: { name: 'CatReorder Store' },
+      create: { name: 'CatReorder Store', ownerId: user.id }
+    });
+
+    categoryA = await prisma.menuCategory.create({
+      data: { name: 'Cat A', storeId: store.id, order: 0 }
+    });
+    categoryB = await prisma.menuCategory.create({
+      data: { name: 'Cat B', storeId: store.id, order: 1 }
+    });
+
+    // 他ストア
+    const otherUser = await prisma.user.create({
+      data: { publicId: 'other-user2', email: 'o2@test.com', role: 'OWNER' }
+    });
+    const otherStore = await prisma.store.create({
+      data: { name: 'OtherStore2', ownerId: otherUser.id }
+    });
+    otherStoreCategory = await prisma.menuCategory.create({
+      data: { name: 'Other Cat', storeId: otherStore.id, order: 0 }
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.menuItem.deleteMany();
+    await prisma.menuCategory.deleteMany();
+    await prisma.store.deleteMany();
+    await prisma.user.deleteMany();
+    await prisma.$disconnect();
+  });
+
+  describe('PUT /api/menu/categories/reorder', () => {
+    it('should reorder categories successfully', async () => {
+      const res = await request(app)
+        .put('/api/menu/categories/reorder')
+        .set('Authorization', 'Bearer test-token')
+        .send({ items: [ { id: categoryA.id, order: 1 }, { id: categoryB.id, order: 0 } ] });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('success', true);
+    });
+
+    it('should fail when including category from another store', async () => {
+      const res = await request(app)
+        .put('/api/menu/categories/reorder')
+        .set('Authorization', 'Bearer test-token')
+        .send({ items: [ { id: categoryA.id, order: 1 }, { id: otherStoreCategory.id, order: 0 } ] });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should fail with invalid payload', async () => {
+      const res = await request(app)
+        .put('/api/menu/categories/reorder')
+        .set('Authorization', 'Bearer test-token')
+        .send({ wrong: 'data' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+}); 


### PR DESCRIPTION
## ✨ 概要
`PUT /api/menu/categories/reorder` エンドポイントに対する統合テストを実装し、並び替えロジックの正常系とバリデーションエラー（他店舗カテゴリー・不正ペイロード）を自動検証できるようにしました。

## 🔄 変更点
- `server/tests/reorderCategories.test.ts` 追加  
  - 正常系: 2 カテゴリーの order 入れ替え → 200 & `success: true`  
  - 他店舗カテゴリー混入 → 400  
  - `items` 配列なし → 400
- 既存コード変更なし

## 🧪 テスト結果
npm test
PASS reorderCategories.test.ts
...
Test Suites: 6 passed
Tests: 27 passed, 2 skipped


## 📚 補足
- これで並び替え API のテストがすべて完了し、P1 項目を一通りカバーできました。
- `docs/sub/progress/task_progress.md` に ✅ 完了 を追記済み。