### PR TITLE
test(frontend): MenuItemList コンポーネントの edit／delete テスト追加 (#phase3)

### DIFF
--- a/client/src/components/MenuItemList.test.tsx
+++ b/client/src/components/MenuItemList.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import MenuItemList from './MenuItemList';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react';
+import { deleteMenuItem } from '../api/menu';
 
 // api/menu.tsの関数をモック
 jest.mock('../api/menu', () => ({
@@ -14,5 +17,36 @@ describe('MenuItemList', () => {
   it('renders without crashing', async () => {
     render(<MenuItemList storeId={1} categoryId={1} onEdit={() => {}} />);
     expect(await screen.findByText(/テストメニュー/)).toBeInTheDocument();
+  });
+
+  it('calls onEdit when edit button is clicked', async () => {
+    const handleEdit = jest.fn();
+    render(<MenuItemList storeId={1} categoryId={1} onEdit={handleEdit} />);
+
+    // ボタンが表示されるまで待機
+    const editButton = await screen.findByRole('button', { name: '編集' });
+    await userEvent.click(editButton);
+
+    expect(handleEdit).toHaveBeenCalledTimes(1);
+    expect(handleEdit).toHaveBeenCalledWith({ id: 1, name: 'テストメニュー', price: 100, categoryId: 1, storeId: 1 });
+  });
+
+  it('calls deleteMenuItem API when delete is confirmed', async () => {
+    // confirm ダイアログを常にOKに
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<MenuItemList storeId={1} categoryId={1} onEdit={() => {}} />);
+
+    const deleteButton = await screen.findByRole('button', { name: '削除' });
+
+    await act(async () => {
+      await userEvent.click(deleteButton);
+    });
+
+    expect(deleteMenuItem).toHaveBeenCalledTimes(1);
+    expect(deleteMenuItem).toHaveBeenCalledWith(1);
+
+    // confirm を元に戻す
+    (window.confirm as jest.Mock).mockRestore();
   });
 }); 

--- a/docs/sub/progress/task_progress.md
+++ b/docs/sub/progress/task_progress.md
@@ -344,3 +344,15 @@
   - モーダル見出しの余白調整（padding-bottom 9px, margin-bottom 7px）
   - `<hr>` のマージンを `0 0 7px` に変更
 - 次のタスクへの引き継ぎ事項: デザイン確認後、追加フィードバックに応じて微調整予定
+
+## 2025-06-24
+### ✅ Frontend: MenuItemList テスト拡充
+- ブランチ: `test/phase3/frontend-menu-item-list`
+- 開始日: 2025-06-24
+- 完了日: 2025-06-24
+- 作業内容:
+  - `MenuItemList.test.tsx` に編集ボタン( onEdit )・削除ボタン( API 呼び出し )のテストケースを追加
+  - `identity-obj-proxy` 対応済みの Jest 設定で実行確認
+  - 全テストグリーン・ESLint エラーなしを確認
+- 引き継ぎ事項:
+  - 他コンポーネント (QRCodeGenerator 等) のテスト拡張を順次実施予定


### PR DESCRIPTION
## 概要
フロントエンドのテスト強化（Phase3）の一環として  
`MenuItemList` コンポーネントの主要アクションをカバーするユニットテストを追加しました。

## 変更内容
1. **client/src/components/MenuItemList.test.tsx**  
   - 編集ボタン押下時に `onEdit` が呼ばれることを検証  
   - 削除ボタン押下 → `window.confirm` 承認後に `deleteMenuItem` が呼ばれることを検証  
2. **docs/sub/progress/task_progress.md**  
   - 本タスク完了の進捗ログを追加  

## テスト結果
```bash
npm --prefix client test
# => Test Suites: 2 passed, 2 total
#    Tests:       5 passed, 5 total
```

## 確認項目
- CI でもテストがグリーンになること  
- 既存機能に影響しないこと（コード変更はテストのみ）