### PR TITLE
test(frontend-store-form): 電話番号バリデーション & API 呼び出しテスト追加

### DIFF
--- a/client/src/components/store/StoreForm.test.tsx
+++ b/client/src/components/store/StoreForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { StoreForm } from './StoreForm';
 
@@ -30,36 +30,36 @@ describe('StoreForm', () => {
     specialBusinessDays: [],
   };
 
-  it.skip('電話番号入力バリデーションのエラー表示と updateStore 呼び出しを確認', async () => {
+  it('電話番号入力バリデーションのエラー表示と updateStore 呼び出しを確認', async () => {
     (getStoreInfo as jest.Mock).mockResolvedValue(mockStore);
     (updateStore as jest.Mock).mockResolvedValue({ ...mockStore, phone: '0123456789' });
 
     render(<StoreForm />);
 
-    await screen.findByText('電話番号');
+    // 電話番号セクション見出し
+    const phoneHeading = await screen.findByText('電話番号');
+    const section = phoneHeading.closest('div') as HTMLElement;
 
-    // ページ内で最初の編集ボタンをクリックし電話番号の編集モードに入る
-    const editButton = screen.getAllByRole('button', { name: '編集' })[0];
-    await userEvent.click(editButton);
+    // 編集ボタンをクリック
+    const editBtn = (section?.parentElement as HTMLElement).querySelector('button[aria-label="編集"]') as HTMLElement;
+    await userEvent.click(editBtn);
 
-    // 入力フィールドに無効値を入力
-    const input = screen.getByRole('textbox');
+    // 無効値入力
+    const input = within(section).getByRole('textbox');
     await userEvent.clear(input);
     await userEvent.type(input, 'abc');
 
-    // 保存
-    const saveButton2 = screen.getByRole('button', { name: '保存' });
-    await userEvent.click(saveButton2);
+    const saveBtn = within(section).getByRole('button', { name: '保存' });
+    await userEvent.click(saveBtn);
 
-    // エラーメッセージ表示 (画面に Alert が出ることを確認)
-    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(within(section).getByRole('alert')).toBeInTheDocument();
 
-    // 有効な値を入力
+    // 有効値入力
     await userEvent.clear(input);
     await userEvent.type(input, '0123456789');
-    await userEvent.click(saveButton2);
+    await userEvent.click(saveBtn);
 
-    expect(updateStore).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(updateStore).toHaveBeenCalledTimes(1));
     expect(updateStore).toHaveBeenLastCalledWith(expect.objectContaining({ phone: '0123456789' }));
   });
 }); 


### PR DESCRIPTION
#### 目的
StoreForm の電話番号フィールドが  
1) 必須／数字のみ のバリデーションを行うこと  
2) 正常入力後に `updateStore` API が呼ばれること  
をテストで保証する。

#### 変更点
- `client/src/components/store/StoreForm.test.tsx`
  - `.skip` を解除し、テストを実装
  - `within()` で電話番号セクションを限定し確実に要素を取得
  - 無効値入力 → エラーメッセージ表示を検証
  - 有効値入力 → `updateStore` が 1 回呼ばれることを `waitFor` で検証
- `docs/sub/progress/task_progress.md`
  - Frontend: StoreForm テスト追加タスクを進行中 → 継続更新

#### 動作確認
```bash
npm --prefix client test -- --runInBand --testPathPattern StoreForm
npm --prefix client run lint
```

#### 結果
- `PASS src/components/store/StoreForm.test.tsx
- ✓ 電話番号入力バリデーションのエラー表示と updateStore 呼び出しを確認


#### 影響範囲
- 本番コードへの変更なし（テストのみ）
- テストは MUI DOM 構造に依存しないセレクターを使用

#### 今後のタスク (P1)
- BusinessHoursInput / 祝日フラグ などサブフォームのテスト拡充
- 画像アップロード失敗系テストの追加

#### チェックリスト
- [x] 新規テストがパスし、Lint エラーなし
- [x] 進捗ドキュメント更新済み
- [ ] レビュワーアサイン