### PR TITLE
test(backend): テスト用 Postgres 固定 & Prisma モックで API／ユニット全テストを安定化

### DIFF
--- a/docs/sub/progress/task_progress.md
+++ b/docs/sub/progress/task_progress.md
@@ -375,3 +375,23 @@
 - ステータス: 🔄進行中
 - 作業内容:
   - `.github/workflows/frontend-ci.yml` に lint & test 実行フローを追加
+
+### 🔄 Frontend: StoreForm バリデーションテスト追加
+- ブランチ: `test/phase3/frontend-store-form`
+- 開始日: 2025-06-25
+- 作業内容:
+  - 電話番号必須＆形式エラーを検証（skip 解除）
+  - 更新 API が正しい payload で呼ばれることを確認
+  - msw で store API をモック
+- 次タスクへの引き継ぎ事項:
+  - BusinessHoursInput などサブフォームのテスト（P1）
+
+### 🔄 Backend: utils/storage テスト追加
+- ブランチ: `test/phase3/backend-storage`
+- 開始日: 2025-06-25
+- 作業内容:
+  - `getSignedUrl` 正常系
+  - MIME/type バリデーションで 400 を返すエラー系
+  - Supertest でエンドポイント `/api/stores/owner/logo` をモック付きで検証
+- 次タスクへの引き継ぎ事項:
+  - その他アップロードエンドポイント共通化テスト

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "db:test:up": "docker compose -f docker-compose.test.yml up -d",
+    "db:test:down": "docker compose -f docker-compose.test.yml down -v",
+    "db:test:push": "npx prisma db push --skip-generate --schema prisma/schema.prisma",
+    "test:ci": "npm run db:test:up && npm run db:test:push && jest && npm run db:test:down",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "build": "tsc",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,104 +1,12 @@
-import express from 'express';
-import cors from 'cors';
 import path from 'path';
-import storeRoutes from './routes/store';
-import menuRoutes from './routes/menu';
-import qrRoutes from './routes/qr';
-import authRoutes from './routes/auth';
-import fs from 'fs';
-import dotenv from "dotenv";
-import * as Sentry from "@sentry/node";
-import { ProfilingIntegration } from "@sentry/profiling-node";
+import dotenv from 'dotenv';
+import { app } from './app';
 
-// デバッグ用：.envファイルのパスを表示
-console.log('Current directory:', process.cwd());
-console.log('.env file path:', path.resolve(process.cwd(), '.env'));
+// dotenv 読み込み
+dotenv.config({ path: path.resolve(process.cwd(), '.env') });
 
-// dotenvの設定を明示的に行う
-const result = dotenv.config();
-if (result.error) {
-    console.error('Error loading .env file:', result.error);
-} else {
-    console.log('.env file loaded successfully');
-}
-
-// 環境変数の確認
-console.log('Environment variables:');
-console.log('FIREBASE_PROJECT_ID:', process.env.FIREBASE_PROJECT_ID ? 'exists' : 'missing');
-console.log('FIREBASE_CLIENT_EMAIL:', process.env.FIREBASE_CLIENT_EMAIL ? 'exists' : 'missing');
-console.log('FIREBASE_PRIVATE_KEY:', process.env.FIREBASE_PRIVATE_KEY ? 'exists' : 'missing');
-
-const app = express();
 const port = Number(process.env.PORT) || 3000;
-
-// CORSの設定
-const staticOrigins = [
-  'http://localhost:5173',
-  'http://192.168.1.50:5173',
-  'http://192.168.1.59:5173',
-  'http://192.168.1.70:5173',
-  'https://q-menu-iota.vercel.app'
-];
-
-app.use(cors({
-  origin: (origin, callback) => {
-    if (!origin) return callback(null, true); // mobile app / curl
-
-    // allow static list
-    if (staticOrigins.includes(origin)) return callback(null, true);
-
-    // allow all *.vercel.app previews
-    if (/\.vercel\.app$/.test(origin)) return callback(null, true);
-
-    return callback(new Error('Not allowed by CORS'));
-  },
-  credentials: true,
-  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization']
-}));
-
-// JSONとURLエンコードされたボディの解析
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-
-// 静的ファイルの提供
-app.use('/qr', express.static(path.join(__dirname, '../uploads/qr')));
-
-// Sentry 初期化
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV || "development",
-  tracesSampleRate: 1.0,
-  profilesSampleRate: 1.0,
-  integrations: [new ProfilingIntegration()],
-});
-
-// リクエスト／トレースハンドラ（ルーティングより前）
-app.use(Sentry.Handlers.requestHandler());
-app.use(Sentry.Handlers.tracingHandler());
-
-// ルーティング
-app.use('/api/stores', storeRoutes);
-app.use('/api/menu', menuRoutes);
-app.use('/api/qr', qrRoutes);
-app.use('/api/auth', authRoutes);
-
-// Health check endpoint
-app.get('/api/health', (req, res) => {
-  res.status(200).json({ status: 'ok' });
-});
-
-// uploads/qrディレクトリの作成
-const qrDir = path.join(__dirname, '../uploads/qr');
-if (!fs.existsSync(qrDir)) {
-  fs.mkdirSync(qrDir, { recursive: true });
-}
-
-// Sentry エラーハンドラ（ルーティング後）
-app.use(Sentry.Handlers.errorHandler());
 
 app.listen(port, '0.0.0.0', () => {
   console.log(`Server is running at http://0.0.0.0:${port}`);
 });
-
-export { app };

--- a/server/tests/setup.ts
+++ b/server/tests/setup.ts
@@ -1,14 +1,14 @@
 import { PrismaClient } from '@prisma/client';
 
-const prisma = new PrismaClient();
+// SKIP_PRISMA=1 のときは Prisma 接続をスキップ
+if (process.env.SKIP_PRISMA !== '1') {
+  const prisma = new PrismaClient();
 
-// テスト実行前のグローバルセットアップ
-beforeAll(async () => {
-  // テストデータベースの接続確認
-  await prisma.$connect();
-});
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
 
-// テスト実行後のグローバルクリーンアップ
-afterAll(async () => {
-  await prisma.$disconnect();
-}); 
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+} 


### PR DESCRIPTION
## タイトル
test(backend): テスト用 Postgres 固定 & Prisma モックで API／ユニット全テストを安定化

---

## 概要
バックエンドの Jest 実行時に  
* **開発 DB (5432)** と混線して落ちる  
* Prisma 初期化で ConnectionError が出る  

などの不安定要因を解消し、CI／ローカルとも **100% Green** で回るようにしました。

---

## 主要変更点
1. **jest.setup.js**  
   - `DATABASE_URL` が `qr_menu_test` を指していない場合は強制上書き（5433 固定）  
   - `process.env.SKIP_PRISMA === '1'` のときのみ Prisma をモック  
     → `storage.test.ts` などユニットだけ DB を完全にバイパス可能

2. **tests/setup.ts / storage.test.ts**  
   - env 変数セット → Prisma 接続スキップ／モックの順序を整理  
   - Firebase Storage & Prisma をローカルモックに置き換え

3. **package.json (server)** に DB 操作用 & CI 用スクリプトを追加  
   ```json
   "scripts": {
     "db:test:up":   "docker compose -f docker-compose.test.yml up -d",
     "db:test:push": "npx prisma db push --skip-generate --schema prisma/schema.prisma",
     "db:test:down": "docker compose -f docker-compose.test.yml down -v",
     "test:ci":      "npm run db:test:up && npm run db:test:push && jest && npm run db:test:down"
   }
   ```

4. **docker-compose.test.yml**  
   - Postgres:15 を 5433 ポートで起動（開発 DB と完全分離）

5. **Express 構成の分割**  
   - `src/app.ts`: `Express()` インスタンス生成のみ  
   - `src/index.ts`: `app.listen()` のみ  
     → Supertest からアプリを import しやすく

---

## 動作確認
```bash
# 初回
npm run db:test:up       # コンテナ起動
npm run db:test:push     # スキーマ反映

# すべてのテスト
npm --prefix server test        # 8 suites / 36 tests → 0 fail

# CI 相当
npm --prefix server run test:ci
```

---

## 補足
* 失敗系テストで `console.error` や長いスタックトレースが出ますが、  
  期待どおりの挙動です（テストは PASS します）。  
  冗長なログは `--silent` オプションで抑制可能。