### PR TITLE
test(phase3): BusinessHoursInput のユニットテスト追加

### DIFF
--- a/client/src/components/store/BusinessHoursInput.test.tsx
+++ b/client/src/components/store/BusinessHoursInput.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BusinessHoursInput } from './BusinessHoursInput';
+import { BusinessHours } from '../../types/store';
+
+// MUI が内部で window.matchMedia を参照するためモックを設定
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+describe('BusinessHoursInput', () => {
+  const closedMonday: BusinessHours[] = [
+    {
+      dayOfWeek: 'monday',
+      periods: [{ isOpen: false, openTime: '09:00', closeTime: '18:00' }],
+    },
+  ];
+
+  it('営業ラジオのクリックで onChange が呼び出される', async () => {
+    const handleChange = jest.fn();
+    render(<BusinessHoursInput value={closedMonday} onChange={handleChange} />);
+
+    const radios = await screen.findAllByRole('radio', { name: '営業' });
+    await userEvent.click(radios[0]);
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    const updated = handleChange.mock.calls[0][0] as BusinessHours[];
+    expect(updated[0].periods[0].isOpen).toBe(true);
+  });
+
+  it('開始と終了が同じ時刻の場合にエラーを表示', async () => {
+    const invalidTime: BusinessHours[] = [
+      {
+        dayOfWeek: 'monday',
+        periods: [{ isOpen: true, openTime: '10:00', closeTime: '10:00' }],
+      },
+    ];
+    render(<BusinessHoursInput value={invalidTime} onChange={() => {}} />);
+
+    expect(
+      await screen.findByText('開始時刻と終了時刻は異なる必要があります')
+    ).toBeInTheDocument();
+  });
+
+  it('時間帯が重複している場合にエラーを表示', async () => {
+    const overlap: BusinessHours[] = [
+      {
+        dayOfWeek: 'monday',
+        periods: [
+          { isOpen: true, openTime: '10:00', closeTime: '11:00' },
+          { isOpen: true, openTime: '10:30', closeTime: '12:00' },
+        ],
+      },
+    ];
+    render(<BusinessHoursInput value={overlap} onChange={() => {}} />);
+
+    expect(await screen.findByText('時間帯が重複しています')).toBeInTheDocument();
+  });
+}); 

--- a/client/src/components/store/BusinessHoursInput.test.tsx
+++ b/client/src/components/store/BusinessHoursInput.test.tsx
@@ -66,6 +66,7 @@ describe('BusinessHoursInput', () => {
     ];
     render(<BusinessHoursInput value={overlap} onChange={() => {}} />);
 
-    expect(await screen.findByText('時間帯が重複しています')).toBeInTheDocument();
+    const errors = await screen.findAllByText('時間帯が重複しています');
+    expect(errors.length).toBeGreaterThan(0);
   });
 }); 


### PR DESCRIPTION
### 1. 背景  
店舗営業時間入力コンポーネント `BusinessHoursInput` には  
- 営業／休業トグル  
- 開始・終了時刻のバリデーション  
- 時間帯重複チェック  

などロジックが集中しており、バグ混入リスクが高いためユニットテストを追加しました。

### 2. 変更内容  
| 種別 | ファイル | 概要 |
|------|----------|------|
| **test** | `client/src/components/store/BusinessHoursInput.test.tsx` | 3 ケース追加<br>1. 営業⇄休業トグルで `onChange` が正しく発火<br>2. 開始＝終了時刻でエラーメッセージ表示<br>3. 時間帯重複でエラーメッセージ表示 |

### 3. テスト結果  
ローカル実行で **client / server 全テスト green**  
```bash
client: 5 suites, 11 tests → PASS  
server: 8 suites, 36 tests (skip 2) → PASS
```

### 4. 関連 Issue / タスク  
- タスク進捗表 🅿️0-1「BusinessHoursInput テスト追加」

### 5. レビュー観点  
- テストケース網羅性に不足がないか  
- MUI `matchMedia` モック実装に問題がないか  
- より効率的なテストアプローチがあればご指摘ください

### 6. 今後の予定  
- 🅿️0 残タスク  
  - `MenuCategoryForm` / `MenuItemForm` テスト追加  
  - `/api/users/*` CRUD のバックエンドテスト