### PR TITLE
fix(phase3): export app from index to fix Render build

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,3 +10,5 @@ const port = Number(process.env.PORT) || 3000;
 app.listen(port, '0.0.0.0', () => {
   console.log(`Server is running at http://0.0.0.0:${port}`);
 });
+
+export { app };


### PR DESCRIPTION
## タイトル
fix(phase3): export app from index to fix Render build

---

## 説明

### 1. 背景  
Render のデプロイで `tsc` が失敗していました。  
- `src/index.ts` が `import { app } from './app'` している一方、`app` を再エクスポートしておらず  
- `src/tests/auth.test.ts` では `import { app } from '../index'` を行っている  

結果として TypeScript エラー  
TS2307: Cannot find module './app'
TS2459: Module '../index' declares 'app' locally, but it is not exported
が発生しビルドが止まっていました。

### 2. 変更内容  
| 種別 | ファイル | 変更点 |
|------|----------|--------|
| **fix** | `server/src/index.ts` | `export { app };` を追加し `app` を再エクスポート |

### 3. 動作確認  
- `cd server && npm run build` → **成功**  
- `npm test`（server / client）→ **すべて PASS**  
- Render 上でも TypeScript ビルドが通過することを期待

### 4. 関連タスク  
- Render ビルドエラー修正

マージ後に Render の自動デプロイが緑になるか確認してください。