### PR TITLE
test(phase3): Backend User CRUD テスト追加 & adminOnly ミドルウェア導入

### DIFF
--- a/client/src/components/QRCodeGenerator.test.tsx
+++ b/client/src/components/QRCodeGenerator.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QRCodeGenerator from './QRCodeGenerator';
+import { generateQRCode } from '../api/qr';
+import { getStoreInfo } from '../api/store';
+
+// モック
+jest.mock('../api/store', () => ({
+  getStoreInfo: jest.fn().mockResolvedValue({ id: '1' }),
+}));
+
+jest.mock('../api/qr', () => ({
+  generateQRCode: jest.fn().mockResolvedValue('/uploads/qr/test.png'),
+}));
+
+describe('QRCodeGenerator', () => {
+  it('storeId 取得後にボタンが表示され、クリックで generateQRCode が呼ばれる', async () => {
+    render(<QRCodeGenerator />);
+
+    const button = await screen.findByRole('button', { name: 'QRコードを生成する' });
+    await userEvent.click(button);
+
+    expect(generateQRCode as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(generateQRCode as jest.Mock).toHaveBeenCalledWith('1');
+
+    expect(await screen.findByAltText('QRコード')).toBeInTheDocument();
+  });
+
+  it('getStoreInfo エラー時にエラーメッセージを表示する', async () => {
+    (getStoreInfo as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+
+    render(<QRCodeGenerator />);
+
+    expect(await screen.findByText('店舗情報の取得に失敗しました')).toBeInTheDocument();
+  });
+}); 

--- a/docs/sub/progress/task_progress.md
+++ b/docs/sub/progress/task_progress.md
@@ -418,3 +418,15 @@
 - 次のタスクへの引き継ぎ事項:
   - Drag-and-Drop の失敗系テスト（P1）
 
+## 2025-06-26
+### 🔄 Backend: User CRUD テスト追加
+- ブランチ: `test/phase3/backend-user-tests`
+- 開始日: 2025-06-26
+- ステータス: 🔄進行中
+- 作業内容:
+  - `/api/users` CRUD エンドポイントの正常系 / 異常系テスト (ADMIN ガード)
+  - Supertest & Jest を用いた統合テスト
+  - テスト用 Prisma seed で管理者 & 一般ユーザーを作成
+- 次のタスクへの引き継ぎ事項:
+  - User ロール別ガードのユニットテスト拡充
+

--- a/server/docker-compose.test.yml
+++ b/server/docker-compose.test.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: qr_menu_test
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import storeRoutes from './routes/store';
 import menuRoutes from './routes/menu';
 import qrRoutes from './routes/qr';
 import authRoutes from './routes/auth';
+import usersRoutes from './routes/users';
 import fs from 'fs';
 import * as Sentry from '@sentry/node';
 import { ProfilingIntegration } from '@sentry/profiling-node';
@@ -62,6 +63,7 @@ app.use('/api/stores', storeRoutes);
 app.use('/api/menu', menuRoutes);
 app.use('/api/qr', qrRoutes);
 app.use('/api/auth', authRoutes);
+app.use('/api/users', usersRoutes);
 
 // Health check
 app.get('/api/health', (_, res) => res.status(200).json({ status: 'ok' }));

--- a/server/src/config/firebase.ts
+++ b/server/src/config/firebase.ts
@@ -38,12 +38,27 @@ const isTestEnvironment = process.env.NODE_ENV === "test";
 export const adminAuth = isTestEnvironment
   ? {
       verifyIdToken: async (token: string) => {
-        // テスト用のモックデータ
-        return {
-          uid: "test-user-id",
-          email: "test@example.com",
-          name: "Test User",
-        };
+        // トークン値に応じてユーザーを切り替え
+        switch (token) {
+          case "admin-token":
+            return {
+              uid: "admin-user-id",
+              email: "admin@example.com",
+              name: "Admin User",
+            } as any;
+          case "owner-token":
+            return {
+              uid: "owner-user-id",
+              email: "owner@example.com",
+              name: "Owner User",
+            } as any;
+          default:
+            return {
+              uid: "test-user-id",
+              email: "test@example.com",
+              name: "Test User",
+            } as any;
+        }
       },
     }
   : admin.auth();

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -20,3 +20,59 @@ export const createUser = async (_req: Request, res: Response) => {
     res.status(500).json({ error: 'ユーザー作成に失敗しました' });
   }
 };
+
+// GET /api/users (admin only)
+export const getUsers = async (_req: Request, res: Response) => {
+  try {
+    const users = await prisma.user.findMany();
+    res.json(users);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'ユーザー取得に失敗しました' });
+  }
+};
+
+// GET /api/users/:id (admin only)
+export const getUserById = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) {
+      res.status(404).json({ error: 'ユーザーが見つかりません' });
+      return;
+    }
+    res.json(user);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'ユーザー取得に失敗しました' });
+  }
+};
+
+// PUT /api/users/:id (admin only)
+export const updateUser = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { email, displayName, role } = req.body;
+
+    const updatedUser = await prisma.user.update({
+      where: { id },
+      data: { email, displayName, role },
+    });
+    res.json(updatedUser);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'ユーザー更新に失敗しました' });
+  }
+};
+
+// DELETE /api/users/:id (admin only)
+export const deleteUser = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    await prisma.user.delete({ where: { id } });
+    res.json({ message: 'ユーザーを削除しました' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'ユーザー削除に失敗しました' });
+  }
+};

--- a/server/src/middleware/adminOnly.ts
+++ b/server/src/middleware/adminOnly.ts
@@ -1,0 +1,15 @@
+import { Response, NextFunction } from "express";
+import { AuthRequest } from "./auth";
+
+// 管理者のみアクセス許可
+export const adminOnly = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): void => {
+  if (req.user?.role !== "ADMIN") {
+    res.status(403).json({ error: "管理者のみがアクセスできます" });
+    return;
+  }
+  next();
+}; 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -13,6 +13,7 @@ export interface AuthRequest extends Request {
     email?: string;
     displayName?: string;
     storeId?: number;
+    role?: string;
   };
 }
 
@@ -88,9 +89,10 @@ export const authenticate = async (
         email: decodedToken.email || undefined,
         displayName: decodedToken.name || undefined,
         storeId: newUser.store.id,
+        role: newUser.role,
       };
     } else {
-      if (!user.store?.id) {
+      if (!user.store?.id && user.role !== "ADMIN") {
         console.error('No store found for existing user');
         res.status(404).json({ error: "Store not found" });
         return;
@@ -101,7 +103,8 @@ export const authenticate = async (
         publicId: user.publicId,
         email: user.email,
         displayName: user.displayName || undefined,
-        storeId: user.store.id,
+        storeId: user.store?.id,
+        role: user.role,
       };
     }
 

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/auth";
+import { adminOnly } from "../middleware/adminOnly";
+import {
+  getUsers,
+  getUserById,
+  createUser,
+  updateUser,
+  deleteUser,
+} from "../controllers/userController";
+
+const router = Router();
+
+// リスト & 作成
+router
+  .route("/")
+  .get(authenticate, adminOnly, getUsers)
+  .post(authenticate, adminOnly, createUser);
+
+// 個別取得・更新・削除
+router
+  .route("/:id")
+  .get(authenticate, adminOnly, getUserById)
+  .put(authenticate, adminOnly, updateUser)
+  .delete(authenticate, adminOnly, deleteUser);
+
+export default router; 

--- a/server/tests/storage.test.ts
+++ b/server/tests/storage.test.ts
@@ -1,0 +1,53 @@
+// Prisma はこのテストでは不要なので完全にモックして DB 初期化を回避
+jest.mock('@prisma/client', () => ({}));
+
+// === Prisma を完全モックする環境変数 ===
+process.env.SKIP_PRISMA = '1';
+
+// Jestのモックは import より先に定義する必要がある
+const mockSave = jest.fn();
+const mockGetSignedUrl = jest.fn().mockResolvedValue(['https://example.com/image.jpg']);
+
+// utils をインポートする前にアンモックして本実装を使用
+jest.unmock('../src/utils/storage');
+
+import { uploadImageToStorage, uploadImage, StorageFolders } from '../src/utils/storage';
+import { storageBucket } from '../src/config/firebase';
+
+// storageBucket.file が未定義の場合に備えて直接モックを設定
+(storageBucket as any).file = () => ({
+  save: mockSave,
+  getSignedUrl: mockGetSignedUrl,
+});
+
+describe('Storage utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uploadImage returns signed url', async () => {
+    mockSave.mockResolvedValue(undefined);
+    const file = {
+      originalname: 'test.png',
+      mimetype: 'image/png',
+      buffer: Buffer.from('data'),
+    } as unknown as Express.Multer.File;
+    const url = await uploadImage(file, StorageFolders.STORE_LOGOS, 'test');
+    expect(url).toBe('https://example.com/image.jpg');
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockGetSignedUrl).toHaveBeenCalled();
+  });
+
+  it('uploadImageToStorage sets jpeg for unknown ext', async () => {
+    mockSave.mockResolvedValue(undefined);
+    await uploadImageToStorage(Buffer.from('data'), 'file.unknown', 'test_folder');
+    const args = mockSave.mock.calls[0][1];
+    expect(args.metadata.contentType).toBe('image/jpeg');
+  });
+
+  it('uploadImage throws when save fails', async () => {
+    mockSave.mockRejectedValue(new Error('save error'));
+    const file = { originalname: 'a.png', mimetype: 'image/png', buffer: Buffer.from('d') } as unknown as Express.Multer.File;
+    await expect(uploadImage(file, StorageFolders.STORE_LOGOS)).rejects.toThrow('Failed to upload image');
+  });
+}); 

--- a/server/tests/store.test.ts
+++ b/server/tests/store.test.ts
@@ -125,9 +125,7 @@ describe('Store API Tests', () => {
 
     it('should return 401 for unauthenticated requests', async () => {
       const response = await request(app)
-        .put('/api/stores/owner/logo')
-        .attach('logo', __dirname + '/dummy-logo.png');
-
+        .put('/api/stores/owner/logo');
       expect(response.status).toBe(401);
     });
 

--- a/server/tests/user.test.ts
+++ b/server/tests/user.test.ts
@@ -1,0 +1,121 @@
+import { PrismaClient } from '@prisma/client';
+import request from 'supertest';
+import { app } from '../src/app';
+
+const prisma = new PrismaClient();
+
+// トークン値に応じて firebase モックが UID を返す設定 (config/firebase.ts)
+const ADMIN_TOKEN = 'admin-token';
+const OWNER_TOKEN = 'owner-token';
+
+describe('User CRUD API (Admin Guard)', () => {
+  let adminUser: any;
+  let ownerUser: any;
+  let targetUser: any; // CRUD 対象
+
+  beforeAll(async () => {
+    // 管理者ユーザーを作成
+    adminUser = await prisma.user.upsert({
+      where: { publicId: 'admin-user-id' },
+      update: {
+        role: 'ADMIN',
+        email: 'admin@example.com',
+        displayName: 'Admin User'
+      },
+      create: {
+        publicId: 'admin-user-id',
+        email: 'admin@example.com',
+        displayName: 'Admin User',
+        role: 'ADMIN'
+      }
+    });
+
+    // 一般ユーザー (OWNER) を作成
+    ownerUser = await prisma.user.upsert({
+      where: { publicId: 'owner-user-id' },
+      update: {
+        role: 'OWNER',
+        email: 'owner@example.com',
+        displayName: 'Owner User'
+      },
+      create: {
+        publicId: 'owner-user-id',
+        email: 'owner@example.com',
+        displayName: 'Owner User',
+        role: 'OWNER'
+      }
+    });
+
+    // CRUD 対象ユーザー
+    targetUser = await prisma.user.upsert({
+      where: { publicId: 'target-user-id' },
+      update: {
+        email: 'target@example.com',
+        displayName: 'Target User',
+        role: 'OWNER'
+      },
+      create: {
+        publicId: 'target-user-id',
+        email: 'target@example.com',
+        displayName: 'Target User',
+        role: 'OWNER'
+      }
+    });
+
+    // OWNER 用のストアを作成（adminOnly 判定まで到達させるため）
+    await prisma.store.upsert({
+      where: { ownerId: ownerUser.id },
+      update: { name: 'Owner Store' },
+      create: { name: 'Owner Store', ownerId: ownerUser.id }
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.store.deleteMany();
+    await prisma.user.deleteMany();
+    await prisma.$disconnect();
+  });
+
+  describe('GET /api/users', () => {
+    it('should allow admin to list users', async () => {
+      const res = await request(app)
+        .get('/api/users')
+        .set('Authorization', `Bearer ${ADMIN_TOKEN}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should forbid non-admin users', async () => {
+      const res = await request(app)
+        .get('/api/users')
+        .set('Authorization', `Bearer ${OWNER_TOKEN}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('DELETE /api/users/:id', () => {
+    it('should allow admin to delete a user', async () => {
+      const res = await request(app)
+        .delete(`/api/users/${targetUser.id}`)
+        .set('Authorization', `Bearer ${ADMIN_TOKEN}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('message');
+
+      // 確認
+      const found = await prisma.user.findUnique({ where: { id: targetUser.id } });
+      expect(found).toBeNull();
+    });
+
+    it('should forbid deletion by non-admin', async () => {
+      const res = await request(app)
+        .delete(`/api/users/${ownerUser.id}`)
+        .set('Authorization', `Bearer ${OWNER_TOKEN}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+}); 


### PR DESCRIPTION
## 概要
Backend `/api/users` エンドポイントに対し、ADMIN 権限ガード付き CRUD テストを実装しました。  
認可ミドルウェアと Firebase テストモックを拡張し、サーバー側の総テスト件数は **40 件（9 スイート）すべてグリーン** です。

## 目的
- ユーザー管理 API の権限漏れ防止
- ADMIN / OWNER ロールを考慮した認可ロジックのテスト網羅
- Render 本番環境へ安全にデプロイするための品質担保

## 主な変更点
1. **adminOnly ミドルウェア**
   - `src/middleware/adminOnly.ts`  
   - `req.user.role !== "ADMIN"` 時に 403 を返却
2. **auth ミドルウェア拡張**
   - `role` を `req.user` に追加  
   - ADMIN ユーザーは store 未登録でも通過させるように条件分岐
3. **/api/users ルート実装**
   - `src/routes/users.ts` で CRUD (GET/POST/PUT/DELETE) を ADMIN 限定公開
   - `src/controllers/userController.ts` に `getUsers, getUserById, updateUser, deleteUser` 追加
4. **Firebase モック強化**
   - テスト環境で渡されたトークン値に応じて UID を切替  
     (`admin-token`, `owner-token`, 既存 `test-token`)
5. **ユニットテスト追加**
   - `tests/user.test.ts`  
     - 一覧取得・削除・権限制御（ADMIN → 200 / OWNER → 403）
   - 既存 `store.test.ts` の未認証ロゴアップロードケースを修正（EPIPE 回避）
6. **既存テスト全件実行結果**
   ```bash
   cd server && npm test
   # 9 Suites, 40 Tests, 0 ❌, 2 ⏭️, 全て PASS
   ```

## 影響範囲
- Express ミドルウェア (`auth.ts`, `adminOnly.ts`)
- Firebase テストモック (`config/firebase.ts`)
- ルーティング (`app.ts`, `routes/users.ts`)
- Prisma User モデル（role は既存カラムのためスキーマ変更なし）

## 動作確認手順
1. `npm install && npm test` で全テストが通過することを確認
2. Postman などで以下を手動確認  
   - `GET /api/users`  
     - Header `Authorization: Bearer admin-token` → 200  
     - Header `Authorization: Bearer owner-token` → 403
   - その他 CRUD エンドポイントのレスポンスが正しいこと

## 関連ドキュメント / Issue
- docs/sub/progress/task_progress.md — 2025-06-26 エントリ
- 🅿️0: Backend 権限テスト拡充

ご確認よろしくお願いします！