### PR TITLE
fix(ui): DescriptionModal の price を任意化しカテゴリー説明でのクラッシュを解消

### DIFF
--- a/client/src/components/DescriptionModal.tsx
+++ b/client/src/components/DescriptionModal.tsx
@@ -4,7 +4,7 @@ import './DescriptionModal.css';
 interface DescriptionModalProps {
   description?: string;
   title: string;
-  price: number;
+  price?: number;
   onClose: () => void;
 }
 
@@ -19,8 +19,12 @@ const DescriptionModal: React.FC<DescriptionModalProps> = ({ description, title,
           </button>
         </div>
         <div className="description-modal-body" style={{ whiteSpace: 'pre-line' }}>
-          <p style={{ fontWeight: 700, margin: '0 0 6px' }}>{price.toLocaleString()}円</p>
-          <hr style={{ border: 'none', borderTop: '1px solid #333', margin: '4px 0 7px' }} />
+          {price !== undefined && (
+            <>
+              <p style={{ fontWeight: 700, margin: '0 0 6px' }}>{price.toLocaleString()}円</p>
+              <hr style={{ border: 'none', borderTop: '1px solid #333', margin: '4px 0 7px' }} />
+            </>
+          )}
           {description && <p style={{ margin: 0 }}>{description}</p>}
         </div>
       </div>


### PR DESCRIPTION
## 概要
カテゴリー一覧で説明文をタップすると `price.toLocaleString()` が `undefined` となりクラッシュしていた不具合を修正しました。  
`DescriptionModal` が **価格必須** の型定義だったため、カテゴリー側から呼び出す際に値がなく例外が発生していました。

## 変更点
- `client/src/components/DescriptionModal.tsx`
  - `price` を `number` → `number | undefined` に変更
  - `price` が渡された場合のみ価格＋区切り線をレンダリング

## 再現手順（修正前）
1. 管理画面 → メニュー管理
2. カテゴリー一覧で説明文をタップ  
3. 画面が真っ白になり、コンソールに `Cannot read properties of undefined (reading 'toLocaleString')`

## 動作確認（修正後）
- [x] カテゴリー説明をタップしてもクラッシュせずモーダルが表示される  
- [x] メニューアイテムの説明モーダルには価格が正常に表示される  
- [x] 他機能（ドラッグ＆ドロップ、編集/削除など）に影響なし

## 影響範囲
- フロントのみ：`DescriptionModal` コンポーネント  
- バックエンド／DB への影響なし

## 関連 Issue
- Close #<Issue 番号を入力>