### PR TITLE
feat(ui): カテゴリー名クリックで全文モーダルを表示できるように追加

### DIFF
--- a/client/src/pages/MenuManagement.tsx
+++ b/client/src/pages/MenuManagement.tsx
@@ -5,6 +5,7 @@ import MenuCategoryForm from '../components/MenuCategoryForm';
 import MenuItemList from '../components/MenuItemList';
 import MenuItemForm from '../components/MenuItemForm';
 import { getStoreInfo } from '../api/store';
+import DescriptionModal from '../components/DescriptionModal';
 
 const MenuManagement: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<MenuCategory | null>(null);
@@ -14,6 +15,7 @@ const MenuManagement: React.FC = () => {
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [itemRefreshTrigger, setItemRefreshTrigger] = useState(0);
   const [storeId, setStoreId] = useState<number | null>(null);
+  const [showTitleModal, setShowTitleModal] = useState(false);
 
   useEffect(() => {
     const fetchStoreId = async () => {
@@ -94,7 +96,8 @@ const MenuManagement: React.FC = () => {
         <div className="mb-8">
           <div className="flex justify-between items-center mb-4">
             <h3
-              className="text-xl font-bold truncate max-w-[70%]"
+              className="text-xl font-bold truncate max-w-[70%] cursor-pointer"
+              onClick={() => setShowTitleModal(true)}
               title={selectedCategory.name}
             >
               {selectedCategory.name}
@@ -130,6 +133,14 @@ const MenuManagement: React.FC = () => {
               categoryId={selectedCategory.id}
               onEdit={handleItemSelect}
               refreshTrigger={itemRefreshTrigger}
+            />
+          )}
+
+          {showTitleModal && (
+            <DescriptionModal
+              title="カテゴリー名"
+              description={selectedCategory.name}
+              onClose={() => setShowTitleModal(false)}
             />
           )}
         </div>


### PR DESCRIPTION
## 概要
カテゴリー名が `truncate` で省略された場合でも、  
クリック／タップで全文をモーダル表示できるようにしました。

## 変更点
- `client/src/pages/MenuManagement.tsx`
  - `DescriptionModal` を import
  - `showTitleModal` ステートを追加
  - 見出し `<h3>` に `cursor-pointer` ＋ `onClick` ハンドラを追加  
  - モーダル (`DescriptionModal`) を条件レンダリング

## 動作確認
- [x] 見出しをクリック／タップ → モーダルに全文が表示される  
- [x] モーダルの「×」または背景タップで閉じる  
- [x] PC でも同様に動作  
- [x] 他機能（並び替え・メニュー追加など）に影響なし

## 影響範囲
- フロントのみ：`MenuManagement.tsx`  
- バックエンド／DB への影響なし

## 関連フェーズ／Issue
- Phase3 UI/UX 改善  
- Close #<Issue 番号を記入>