### PR TITLE
fix(ui): 画像モーダルをポータル化して背面カードの浮き上がりを解消

### DIFF
--- a/client/src/components/ImageModal.tsx
+++ b/client/src/components/ImageModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import './ImageModal.css';
 
 interface ImageModalProps {
@@ -28,7 +29,7 @@ const ImageModal: React.FC<ImageModalProps> = ({ imageUrl, alt, onClose }) => {
     };
   }, [onClose]);
 
-  return (
+  const modal = (
     <div className="image-modal-backdrop" onClick={handleBackdropClick}>
       <div className="image-modal-content">
         <button className="image-modal-close" onClick={onClose} aria-label="閉じる">
@@ -38,6 +39,8 @@ const ImageModal: React.FC<ImageModalProps> = ({ imageUrl, alt, onClose }) => {
       </div>
     </div>
   );
+
+  return createPortal(modal, document.body);
 };
 
 export default ImageModal; 


### PR DESCRIPTION
## 概要
画像クリック時に `ImageModal` を表示すると、  
背面にある他のアイテムカードが “浮き上がる” ように見える問題を修正しました。

## 変更点
| 種別 | 変更内容 |
|------|----------|
| **表示位置** | `ImageModal` を `createPortal` で `<body>` 直下に描画 |
| **コード** | `client/src/components/ImageModal.tsx` に `createPortal` を追加し、JSX をポータル経由で返却 |

## 動作確認
- [x] 画像クリック → 画像モーダルが表示されても背面カードは影響を受けない  
- [x] モーダルの×または背景クリック・ESC で正常に閉じる  
- [x] 他機能（説明モーダル、並び替え、編集／削除ボタンなど）に影響なし  

## 影響範囲
- フロントのみ：`ImageModal.tsx`  
- バックエンド／DB への影響なし  

## 関連フェーズ／Issue
- Phase3 UI/UX 改善  
- Close #<Issue 番号を記入>