### PR TITLE
feat(infra): Cloud SQL インスタンス & DATABASE_URL シークレット追加

### DIFF
--- a/docs/sub/progress/task_progress.md
+++ b/docs/sub/progress/task_progress.md
@@ -438,3 +438,8 @@
 開始日: 2025-07-06
 作業内容: Terraform backend/provider 作成
 
+🔄進行中
+ブランチ: feature/phase1/cloud-sql
+開始日: 2025-07-06
+作業内容: Cloud SQL インスタンス + Secret Manager 定義
+

--- a/infra/cloudsql.tf
+++ b/infra/cloudsql.tf
@@ -1,0 +1,48 @@
+resource "random_password" "dbpass" {
+  length  = 16
+  special = true
+}
+
+resource "google_sql_database_instance" "qrmenu" {
+  name             = "qrmenu-db"
+  database_version = "POSTGRES_16"
+  region           = "asia-northeast1"
+
+  settings {
+    tier = "db-f1-micro" # 最小構成、後でスケールアップ可
+
+    ip_configuration {
+      ipv4_enabled = true # 初期は Public IP、後で Private に変更予定
+    }
+
+    availability_type = "ZONAL"
+
+    backup_configuration {
+      enabled = true
+    }
+  }
+}
+
+resource "google_sql_database" "app" {
+  name     = "app"
+  instance = google_sql_database_instance.qrmenu.name
+}
+
+resource "google_sql_user" "appuser" {
+  name     = "appuser"
+  password = random_password.dbpass.result
+  instance = google_sql_database_instance.qrmenu.name
+}
+
+# Secret Manager に接続文字列を保存
+resource "google_secret_manager_secret" "database_url" {
+  secret_id = "DATABASE_URL"
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "database_url_v1" {
+  secret      = google_secret_manager_secret.database_url.id
+  secret_data = "postgresql://${google_sql_user.appuser.name}:${random_password.dbpass.result}@${google_sql_database_instance.qrmenu.ip_address[0].ip_address}:5432/${google_sql_database.app.name}"
+} 

--- a/infra/random.tf
+++ b/infra/random.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+} 


### PR DESCRIPTION
## 目的
アプリ用 PostgreSQL インスタンスと接続情報 (DATABASE_URL) を Terraform で構築・管理できるようにします。  
※まだ `terraform apply` は実施していません。マージ後に実行予定です。

---

## 変更点
### 追加
| ファイル | 内容 |
|----------|------|
| `infra/cloudsql.tf` | Cloud SQL インスタンス / データベース / ユーザ / Secret Manager への接続文字列登録 |
| `infra/random.tf`  | `hashicorp/random` プロバイダー宣言 |
| `docs/sub/progress/task_progress.md` | Cloud SQL 作業の進捗を追記 |

### 主なリソース
- **google_sql_database_instance.qrmenu**  
  - PostgreSQL 16 / `db-f1-micro` / asia-northeast1  
  - 自動バックアップ有効
- **google_sql_database.app** : アプリ本番用 DB
- **google_sql_user.appuser** : アプリ用ユーザ (ランダム生成パスワード)
- **google_secret_manager_secret.DATABASE_URL**  
  - 例: `postgresql://appuser:XXXXXXXX@<PUBLIC_IP>:5432/app`

---

## 動作確認手順
1. **初期化**  
   ```bash
   cd infra
   terraform init
   ```
2. **Plan**  
   ```bash
   terraform plan -out=tfplan
   ```  
   で差分とリソース数を確認
3. **Apply (マージ後に実施)**  
   ```bash
   terraform apply tfplan
   ```  
   作成完了まで 4 – 6 分程度

---

## 今後の予定
1. `server/` ディレクトリに Dockerfile を追加（別 PR）  
2. Artifact Registry & Cloud Run 定義  
3. Cloud Build トリガーで CI/CD 構築  
4. Cloud SQL を Private IP に切り替え（Serverless VPC Connector 利用）

---

## レビュー観点
- インスタンスの命名・リージョン・マシンタイプに問題がないか  
- Secret Manager への接続文字列の保存方法  
- 今後のリソース追加フローに関するフィードバック