### PR TITLE
feat(deploy): Artifact Registry・Cloud Run・Cloud Build CI/CD を追加

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,27 @@
+steps:
+  - id: "Build"
+    name: "gcr.io/cloud-builders/docker"
+    args: ["build","-t","$_IMAGE","-f","server/Dockerfile","."]
+
+  - id: "Push"
+    name: "gcr.io/cloud-builders/docker"
+    args: ["push","$_IMAGE"]
+
+  - id: "Deploy"
+    name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - qrmenu-api
+      - --image=$_IMAGE
+      - --region=asia-northeast1
+      - --platform=managed
+      - --service-account=qrmenu-run-sa@${PROJECT_ID}.iam.gserviceaccount.com
+      - --quiet
+
+images:
+  - "$_IMAGE"
+
+substitutions:
+  _IMAGE: "asia-northeast1-docker.pkg.dev/$PROJECT_ID/qrmenu/qrmenu-api:$SHORT_SHA" 

--- a/docs/sub/progress/task_progress.md
+++ b/docs/sub/progress/task_progress.md
@@ -448,3 +448,8 @@
 開始日: 2025-07-06
 作業内容: Cloud SQL インスタンス + Secret Manager 定義
 
+🔄進行中
+ブランチ: feature/phase2/run-deploy
+開始日: 2025-07-06
+作業内容: Artifact Registry, Cloud Run, Cloud Build トリガー定義
+

--- a/infra/artifact_run.tf
+++ b/infra/artifact_run.tf
@@ -1,0 +1,45 @@
+resource "google_artifact_registry_repository" "qrmenu" {
+  provider      = google-beta
+  location      = "asia-northeast1"
+  repository_id = "qrmenu"
+  format        = "DOCKER"
+}
+
+resource "google_cloud_run_service" "api" {
+  name     = "qrmenu-api"
+  location = "asia-northeast1"
+
+  template {
+    spec {
+      service_account_name = "qrmenu-run-sa@${var.project_id}.iam.gserviceaccount.com"
+
+      containers {
+        image = "asia-northeast1-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.qrmenu.repository_id}/qrmenu-api:latest"
+
+        env {
+          name = "DATABASE_URL"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.database_url.secret_id
+              key  = "latest"
+            }
+          }
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  autogenerate_revision_name = true
+}
+
+resource "google_cloud_run_service_iam_member" "public_invoker" {
+  service  = google_cloud_run_service.api.name
+  location = google_cloud_run_service.api.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+} 

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,4 +1,9 @@
 provider "google" {
-  project = "qrmenu-34cc1"
+  project = var.project_id
+  region  = "asia-northeast1"
+}
+
+provider "google-beta" {
+  project = var.project_id
   region  = "asia-northeast1"
 } 


### PR DESCRIPTION
## 目的
GCP への自動デプロイ基盤を構築するため、  
以下 3 つのリソース/設定を Terraform と Cloud Build で追加しました。

1. Artifact Registry（Docker）
2. Cloud Run サービス
3. Cloud Build パイプライン（main push で Build → Push → Deploy）

---

## 変更点
| ファイル | 内容 |
|----------|------|
| `infra/artifact_run.tf` | Artifact Registry / Cloud Run / IAM Invoker を定義 |
| `infra/provider.tf` | `google-beta` プロバイダーを追加 |
| `cloudbuild.yaml` | Build → Push → Deploy のステップを記述 |
| `docs/sub/progress/task_progress.md` | 進捗を追記 |

---

### Artifact Registry
```hcl
google_artifact_registry_repository.qrmenu
location      = asia-northeast1
repository_id = qrmenu
format        = DOCKER
```

### Cloud Run Service
- サービス名: `qrmenu-api`
- リージョン : asia-northeast1
- イメージ   : `asia-northeast1-docker.pkg.dev/$PROJECT_ID/qrmenu/qrmenu-api:latest`
- サービスアカウント: `qrmenu-run-sa`
- DATABASE_URL を Secret Manager から参照
- Invoker を `allUsers` に公開（後で制限可）

### Cloud Build
1. Docker ビルド (`server/Dockerfile`)
2. Artifact Registry へ push
3. `gcloud run deploy` で Cloud Run 更新

---

## 動作確認手順
1. **Terraform**  
   ```bash
   cd infra
   terraform init
   terraform plan   # 差分確認
   terraform apply  # リポジトリ & Cloud Run 作成
   ```
2. **Cloud Build トリガー**  
   - GitHub 連携で「main ブランチ push」を作成
3. **デプロイ確認**  
   - main に push → Cloud Build が成功  
   - Cloud Run URL で `GET /health` が 200 を返す

---

## 今後の課題
- Cloud Run を Private IP & Serverless VPC Connector に切替
- Invoker IAM を適切なロールに限定（Auth 実装後）
- Staging 環境用の別プロジェクト／サービス分割
- Cloud Monitoring / Error Reporting の導入

---

## レビュー観点
- Cloud Run / Artifact Registry の命名・リージョン  
- Cloud Build YAML のステップ・権限  
- Invoker 公開設定の妥当性（暫定で allUsers）