### PR TITLE
fix(infra): Secret Manager の replication を user_managed に修正

### DIFF
--- a/infra/cloudsql.tf
+++ b/infra/cloudsql.tf
@@ -38,7 +38,11 @@ resource "google_sql_user" "appuser" {
 resource "google_secret_manager_secret" "database_url" {
   secret_id = "DATABASE_URL"
   replication {
-    automatic = true
+    user_managed {
+      replicas {
+        location = "asia-northeast1"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### 目的
Terraform 0.14 以降 + google provider v6.42 では  
`google_secret_manager_secret` リソースで **`replication.automatic`** ブロックが
未サポートのため `terraform validate` が失敗していました。

### 変更点
* `infra/cloudsql.tf`
  * `google_secret_manager_secret "database_url"` の `replication` を  
    `automatic {}` → `user_managed { replicas { location = "asia-northeast1" } }`  
    に置き換え。

### 動作確認
```bash
# 依存プラグインの初期化（ステートレス）
terraform init -backend=false -input=false

# 構文 & プロバイダ検証
terraform validate   # => Success! The configuration is valid.
```

### 影響範囲
* Secret Manager にまだ `DATABASE_URL` が存在しない前提での変更です。  
  既に作成済みの場合は **replication ポリシーが immutable** のため
  `terraform destroy` → `apply` で再作成が必要になります。

### 関連タスク
* #\<Issue 番号\>（あれば）

### レビュア向けメモ
* 他リソースへの影響はありません。
* マージ後は以下を実行してください。
  1. `terraform apply`
  2. Cloud Build トリガー作成 & デプロイ確認