### PR TITLE
fix(infra): Cloud SQL を Enterprise 化 & Cloud Run デプロイを Cloud Build に委譲

### DIFF
--- a/infra/artifact_run.tf
+++ b/infra/artifact_run.tf
@@ -3,43 +3,4 @@ resource "google_artifact_registry_repository" "qrmenu" {
   location      = "asia-northeast1"
   repository_id = "qrmenu"
   format        = "DOCKER"
-}
-
-resource "google_cloud_run_service" "api" {
-  name     = "qrmenu-api"
-  location = "asia-northeast1"
-
-  template {
-    spec {
-      service_account_name = "qrmenu-run-sa@${var.project_id}.iam.gserviceaccount.com"
-
-      containers {
-        image = "asia-northeast1-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.qrmenu.repository_id}/qrmenu-api:latest"
-
-        env {
-          name = "DATABASE_URL"
-          value_from {
-            secret_key_ref {
-              name = google_secret_manager_secret.database_url.secret_id
-              key  = "latest"
-            }
-          }
-        }
-      }
-    }
-  }
-
-  traffic {
-    percent         = 100
-    latest_revision = true
-  }
-
-  autogenerate_revision_name = true
-}
-
-resource "google_cloud_run_service_iam_member" "public_invoker" {
-  service  = google_cloud_run_service.api.name
-  location = google_cloud_run_service.api.location
-  role     = "roles/run.invoker"
-  member   = "allUsers"
 } 

--- a/infra/cloudsql.tf
+++ b/infra/cloudsql.tf
@@ -6,6 +6,7 @@ resource "random_password" "dbpass" {
 resource "google_sql_database_instance" "qrmenu" {
   name             = "qrmenu-db"
   database_version = "POSTGRES_16"
+  edition          = "ENTERPRISE"
   region           = "asia-northeast1"
 
   settings {


### PR DESCRIPTION
### 背景
`terraform apply` 時に下記 2 つのエラーが発生していました。

1. **Cloud SQL**
   ```
   Invalid Tier (db-f1-micro) for (ENTERPRISE_PLUS) Edition.
   ```
   → PostgreSQL 16 ではデフォルト Edition が *Enterprise Plus* となり  
     `db-f1-micro` が選択不可。

2. **Cloud Run**
   ```
   Image '.../qrmenu-api:latest' not found
   ```
   → Terraform がイメージ未 Push の状態で Cloud Run を作成しようとして失敗。

### 目的
* Cloud SQL を *Enterprise* Edition に固定し、`db-f1-micro` 構成を許可。
* Cloud Run サービス定義を Terraform から除外し、  
  **Cloud Build → Artifact Registry → Cloud Run** のパイプラインに一本化。

### 変更点
| ファイル | 変更内容 |
|---------|----------|
| `infra/cloudsql.tf` | `edition = "ENTERPRISE"` を追加 |
| `infra/artifact_run.tf` | `google_cloud_run_service` & `iam_member` を削除（Artifact Registry は残置） |

### 動作確認
```bash
# 構文チェック
terraform validate          # => Success

# (本番適用前) 計画を確認
terraform plan
```
* Cloud SQL が `db-f1-micro / ENTERPRISE` で作成可能になることを確認。
* Cloud Run リソースは削除され、Cloud Build 側でのデプロイのみが残る。

### 影響範囲
* 既存の Cloud Run サービスが Terraform 管理外になります。  
  Cloud Build トリガーで `main` へ Push すると自動デプロイされる想定です。
* それ以外のリソースには影響ありません。

### 関連 Issue / PR
* #<番号あれば>