### PR TITLE
feat(cloudsql): PG16 対応のためカスタム Tier へ変更 & edition 引数削除

### DIFF
--- a/docs/sub/progress/task_progress.md
+++ b/docs/sub/progress/task_progress.md
@@ -453,3 +453,15 @@
 開始日: 2025-07-06
 作業内容: Artifact Registry, Cloud Run, Cloud Build トリガー定義
 
+## 2025-07-12
+### 🔄 Cloud SQL PG16 Edition/Tier fix
+- ブランチ: `feature/phase3/cloudsql-fix`
+- 開始日: 2025-07-12
+- ステータス: 🔄進行中
+- 作業内容:
+  - Cloud SQL インスタンスの edition/tier 設定を PG16 に対応させる
+  - google-beta provider 追加 または tier をカスタムへ変更
+  - Secret Manager の DATABASE_URL を自動生成
+- 次のタスク:
+  - terraform apply 完了後にパイプライン接続を確認
+

--- a/infra/cloudsql.tf
+++ b/infra/cloudsql.tf
@@ -4,13 +4,13 @@ resource "random_password" "dbpass" {
 }
 
 resource "google_sql_database_instance" "qrmenu" {
+  provider = google-beta
   name             = "qrmenu-db"
   database_version = "POSTGRES_16"
-  edition          = "ENTERPRISE"
   region           = "asia-northeast1"
 
   settings {
-    tier = "db-f1-micro" # 最小構成、後でスケールアップ可
+    tier = "db-custom-1-3840" # PG16 対応最小構成 (1vCPU, 3.75GB)
 
     ip_configuration {
       ipv4_enabled = true # 初期は Public IP、後で Private に変更予定


### PR DESCRIPTION
## 背景  
Terraform で Cloud SQL（PostgreSQL 16）を作成する際、

- `edition = "ENTERPRISE"` 引数は provider v6.42.0 では未サポート
- デフォルト Edition が *Enterprise Plus* となり `db-f1-micro` Tier が使えない

という 2 点が原因で `terraform apply` が失敗していました。

## 変更点  
| ファイル | 変更内容 |
|----------|----------|
| `infra/cloudsql.tf` | 1. `provider = google-beta` を指定<br>2. `edition` 引数を削除<br>3. Tier を `db-f1-micro` → `db-custom-1-3840`（1 vCPU / 3.75 GB）へ変更 |
| `docs/sub/progress/task_progress.md` | 進捗を 🔄 で記録 |

## 動作確認  
```bash
# 構文チェック
terraform -chdir=infra validate   # => Success

# 実行プラン
terraform -chdir=infra plan       # => Cloud SQL インスタンスが作成されることを確認
```

## 影響範囲  
- Cloud SQL のマシンタイプが Shared Core `db-f1-micro` から Custom に変わります（最小構成 1 vCPU）。  
- インスタンス名・リージョン・DB 名などは変更ありません。  

## 今後の課題  
- 必要に応じて `edition = "ENTERPRISE"` が provider でサポートされた際に戻すか再検討。  
- Secret Manager の `DATABASE_URL` 自動更新ロジックの実装。  
- Cloud Run ↔︎ Cloud SQL 接続（Auth Proxy/VPC コネクタ）の設定。  

## 関連 Issue / PR  
- N/A