### PR TITLE
feat(ci): GitHub→Cloud Build トリガー追加（main ブランチ自動デプロイ）

### DIFF
--- a/docs/sub/progress/task_progress.md
+++ b/docs/sub/progress/task_progress.md
@@ -487,3 +487,14 @@
 - 次のタスク:
   - テストデプロイ後に動作確認し PR 作成
 
+### 🔄 Cloud Build トリガー作成
+- ブランチ: `feature/phase3/cloudbuild-trigger`
+- 開始日: 2025-07-12
+- ステータス: 🔄進行中
+- 作業内容:
+  - github push trigger (main) 定義 (google_cloudbuild_trigger)
+  - cloudbuild.yaml を参照し _REGION 変数を置換
+  - Terraform で適用予定
+- 次のタスク:
+  - terraform apply 後 push テスト
+

--- a/infra/cloudbuild_trigger.tf
+++ b/infra/cloudbuild_trigger.tf
@@ -1,0 +1,22 @@
+resource "google_cloudbuild_trigger" "qrmenu_main" {
+  provider    = google-beta
+  name        = "qrmenu-main-trigger"
+  description = "Trigger Cloud Build on push to main branch"
+
+  github {
+    owner = "mashiroreo"
+    name  = "qr-menu"
+    push {
+      branch = "^main$"
+    }
+  }
+
+  filename = "cloudbuild.yaml"
+
+  substitutions = {
+    _REGION = "asia-northeast1"
+  }
+
+  # Service account executing builds (Cloud Build default SA)
+  included_files = [ "**" ]
+} 


### PR DESCRIPTION
## 背景
Cloud Build パイプラインを main ブランチへ Push するたびに自動実行し、  
ビルド → Artifact Registry への Push → Cloud Run デプロイを完全自動化させるため、  
GitHub 連携トリガーを Terraform でコード化します。

## 変更点
| ファイル | 変更内容 |
|----------|----------|
| `infra/cloudbuild_trigger.tf` | `google_cloudbuild_trigger` を追加<br>  - GitHub リポジトリ `mashiroreo/qr-menu`<br>  - ブランチ `main` に Push で発火<br>  - `cloudbuild.yaml` を実行<br>  - `_REGION` 置換サブスティテューション |
| `docs/sub/progress/task_progress.md` | Cloud Build トリガータスクを 🔄 で記録 |

## 適用手順
```bash
# 1. トリガーを作成
terraform -chdir=infra apply

# 2. 動作確認
git checkout -b test/trigger-check
echo "# ping" >> README.md
git commit -am "chore: trigger test"
git push origin test/trigger-check
# → GitHub で PR → merge → Cloud Build が自動実行されることを確認
```

## 動作確認項目
- Cloud Build が `Build / Push / Deploy` 全ステップ成功  
- Cloud Run に新リビジョンが作成され、サービスが正常起動  
- Secret `DATABASE_URL` が環境変数として反映されている  

## 影響範囲
- main ブランチへの Push で常に最新アプリがデプロイされます。  
- 手動 `gcloud run deploy` は不要になります。  

## 今後の課題
- PR 時点で `pull_request` トリガー (ビルドのみ) を追加して CI を強化  
- Slack など通知チャネル連携  
- Post-deploy Smoke Test の自動実行

## 関連 Issue / PR
- #N/A