### PR TITLE
fix(ci): Cloud Build GitHub trigger branch 正規表現をプレーンに修正

### DIFF
--- a/infra/cloudbuild_trigger.tf
+++ b/infra/cloudbuild_trigger.tf
@@ -7,7 +7,7 @@ resource "google_cloudbuild_trigger" "qrmenu_main" {
     owner = "mashiroreo"
     name  = "qr-menu"
     push {
-      branch = "^main$"
+      branch = "main"
     }
   }
 


### PR DESCRIPTION
## 背景
`^main$` の正規表現が Cloud Build GitHub トリガー API で
`invalid argument` と判定されたため、プレーンな `main` 指定に変更します。

## 変更点
| ファイル | 変更内容 |
|----------|----------|
| `infra/cloudbuild_trigger.tf` | `branch = "^main$"` → `branch = "main"` |

## 動作確認
1. PR マージ
2. `terraform -chdir=infra apply -auto-approve`
   - `google_cloudbuild_trigger.qrmenu_main` が作成されること
3. main ブランチへコミットを Push
   - Cloud Build → Build / Deploy が自動実行されること

## 影響範囲
CI/CD トリガーのみ。アプリ・インフラその他のリソースに影響なし。