### PR TITLE
fix(ci): Cloud Build GitHub トリガーに asia-northeast1 リージョンを指定

### DIFF
--- a/docs/sub/progress/task_progress.md
+++ b/docs/sub/progress/task_progress.md
@@ -508,3 +508,12 @@
 - 次のタスク:
   - terraform apply 後再度デプロイ確認
 
+### 🔄 Cloud Build Trigger location 修正
+- ブランチ: `fix/phase3/cloudbuild-trigger-location`
+- 開始日: 2025-07-12
+- ステータス: 🔄進行中
+- 作業内容:
+  - Trigger resource に `location = "asia-northeast1"` を追加
+- 次のタスク:
+  - terraform apply で作成確認
+

--- a/infra/cloudbuild_trigger.tf
+++ b/infra/cloudbuild_trigger.tf
@@ -2,6 +2,7 @@ resource "google_cloudbuild_trigger" "qrmenu_main" {
   provider    = google-beta
   name        = "qrmenu-main-trigger"
   description = "Trigger Cloud Build on push to main branch"
+  location    = "asia-northeast1"
 
   github {
     owner = "mashiroreo"


### PR DESCRIPTION
## 背景
GitHub 接続を asia-northeast1 で作成したにもかかわらず、
Cloud Build トリガー側はデフォルト `global` リージョンのままでした。
そのため Terraform でトリガー作成時に  
`invalid argument` (Error 400) が発生していました。

## 変更点
| ファイル | 変更内容 |
|----------|----------|
| `infra/cloudbuild_trigger.tf` | `location = "asia-northeast1"` を追加 |
| `docs/sub/progress/task_progress.md` | トリガー修正タスクを 🔄 で記録 |

## 動作確認
1. PR マージ後  
   ```bash
   terraform -chdir=infra apply -auto-approve
   ```
   - `google_cloudbuild_trigger.qrmenu_main` が **作成成功** することを確認
2. main ブランチへ軽いコミットを Push
   - Cloud Build が自動実行され、Build ➜ Push ➜ Deploy が完了
   - Cloud Run の新リビジョンが作成される

## 影響範囲
CI/CD トリガーのみ。既存のインフラやアプリケーションコードには影響なし。

## 関連 Issue / PR
- #N/A