### PR TITLE
fix(cloudbuild): Cloud Build トリガーに service_account & logging オプションを追加

### DIFF
--- a/infra/cloudbuild_trigger.tf
+++ b/infra/cloudbuild_trigger.tf
@@ -18,6 +18,14 @@ resource "google_cloudbuild_trigger" "qrmenu_main" {
     _REGION = "asia-northeast1"
   }
 
+  service_account = "projects/${var.project_id}/serviceAccounts/cloudbuild-trigger-sa@${var.project_id}.iam.gserviceaccount.com"
+
+  build {
+    options {
+      logging = "CLOUD_LOGGING_ONLY"
+    }
+  }
+
   # Service account executing builds (Cloud Build default SA)
   included_files = [ "**" ]
 } 


### PR DESCRIPTION
## 概要
ユーザー管理のサービスアカウント `cloudbuild-trigger-sa` を Cloud Build トリガーに指定したところ、  
ビルド実行時に下記エラーが発生しました。

> if 'build.service_account' is specified, the build must either  
> (a) specify 'build.logs_bucket',  
> (b) use the REGIONAL_USER_OWNED_BUCKET build.options.default_logs_bucket_behavior option,  
> or (c) use either CLOUD_LOGGING_ONLY / NONE logging options: invalid argument

本 PR では **Option (c)** を採用し、Cloud Logging のみを使用するよう設定を追加しました。

## 変更点
- `infra/cloudbuild_trigger.tf`
  - `service_account` フィールドを明示的に指定  
  - `build { options { logging = "CLOUD_LOGGING_ONLY" } }` を追加し、ログバケット不要でビルド可能に

## 背景
ユーザー管理 SA を指定すると Cloud Build はログ保存先を必須とする仕様。  
既存トリガーはデフォルト SA 想定のため、オプション追加が必要だった。

## 動作確認
1. `terraform apply` を実行しトリガーを更新  
2. `main` ブランチへダミーコミットを push  
3. Cloud Build が SUCCESS し、新リビジョンが Cloud Run にデプロイされることを確認  
   - 確認ログ: Cloud Build → ビルド履歴  
   - Cloud Run `/health` エンドポイントで 200 を確認

## 影響範囲
- Cloud Build トリガー構成のみ。アプリケーションコードやインフラ他リソースには影響なし。

## 今後の課題
- トリガーリソースを Terraform 管理へ完全移行したため、UI 変更を避ける  
- 必要であれば `REGIONAL_USER_OWNED_BUCKET` 方式への切替を検討

## 関連 Issue / PR
- #<issue-number-if-any>