### PR TITLE
fix(cloudbuild): Terraform 変数誤展開を防ぐため $$ で Cloud Build 置換変数をエスケープ

### DIFF
--- a/infra/cloudbuild_trigger.tf
+++ b/infra/cloudbuild_trigger.tf
@@ -38,8 +38,8 @@ resource "google_cloudbuild_trigger" "qrmenu_main" {
         "--image=$_IMAGE",
         "--region=$_REGION",
         "--platform=managed",
-        "--service-account=qrmenu-run-sa@${PROJECT_ID}.iam.gserviceaccount.com",
-        "--update-secrets=DATABASE_URL=projects/$PROJECT_NUMBER/secrets/DATABASE_URL:latest",
+        "--service-account=qrmenu-run-sa@$${PROJECT_ID}.iam.gserviceaccount.com",
+        "--update-secrets=DATABASE_URL=projects/$${PROJECT_NUMBER}/secrets/DATABASE_URL:latest",
         "--add-cloudsql-instances=qrmenu-db",
         "--quiet",
       ]
@@ -48,7 +48,7 @@ resource "google_cloudbuild_trigger" "qrmenu_main" {
     images = ["$_IMAGE"]
 
     substitutions = {
-      _IMAGE  = "asia-northeast1-docker.pkg.dev/${var.project_id}/qrmenu/qrmenu-api:$SHORT_SHA"
+      _IMAGE  = "asia-northeast1-docker.pkg.dev/${var.project_id}/qrmenu/qrmenu-api:$${SHORT_SHA}"
       _REGION = "asia-northeast1"
     }
 


### PR DESCRIPTION
## 概要
Terraform が `${PROJECT_ID}` 等を式として解釈しないよう、  
Cloud Build コマンド内の変数を `$$` でエスケープしました。

## 変更点
- **infra/cloudbuild_trigger.tf**
  - `--service-account` と `--update-secrets` に含まれる  
    `${PROJECT_ID}` / `${PROJECT_NUMBER}` を → `$$` 付きに変更  
  - `substitutions` 内 `_IMAGE` の `${SHORT_SHA}` も `$$SHORT_SHA` へ変更

## 背景
- インライン build 定義に移行後、Terraform apply 時に  
  `${PROJECT_ID}` などをリソース参照と誤認し **Invalid reference** エラー発生
- `$$` ダブルドルで escape することで、Cloud Build 実行時のみ展開される

## 動作確認手順
1. `terraform apply` がエラー無く完了することを確認  
2. main ブランチへダミーコミット → Cloud Build が SUCCESS  
3. Cloud Build の Deploy ステップで正しい `PROJECT_ID` / `PROJECT_NUMBER` が展開されていることをログで確認

## 影響範囲
- Cloud Build トリガーの inline build コマンド文字列のみ  
- その他リソース、アプリケーションコードには影響なし

## リスクと互換性
- $$ エスケープのみでロジック変更は無いため低リスク  
- 本番反映前に 1 回パイプラインを手動実行して確認推奨

## 関連 PR
- [refactor/phase3/cloudbuild-trigger-inline](https://github.com/mashiroreo/qr-menu/pull/XXX)  
  （inline build 定義へ移行した前回 PR）